### PR TITLE
Basic support for table joins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,11 @@ jobs:
           poetry run pytest -v --continue-on-collection-errors
         env:
           ICEAXE_LOG_LEVEL: DEBUG
+      - name: Run integration tests
+        run: |
+          poetry run pytest -v --continue-on-collection-errors -m integration_tests
+        env:
+          ICEAXE_LOG_LEVEL: DEBUG
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 A modern, fast ORM for Python. We have the following goals:
 
-- **Performance**: We want to exceed or match the fastest ORMs in Python.
+- **Performance**: We want to exceed or match the fastest ORMs in Python. We want our ORM to be as close as possible to raw-[asyncpg](https://github.com/MagicStack/asyncpg) speeds.
 - **Typehinting**: Everything should be typehinted with expected types.
 - **Postgres only**: Leverage native Postgres features and simplify the implementation.
 - **Common is easy, rare is possible**: If you're writing _really_ complex queries, these are better done by hand so you can see exactly what SQL will be run by.
+
+Iceaxe is an independent project. It's compatible with the [Mountaineer](https://github.com/piercefreeman/mountaineer) ecosystem, but you can use it in whatever
+project and web framework you're using.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # iceaxe
 
-A modern, fast ORM for Python.
+A modern, fast ORM for Python. We have the following goals:
+
+- **Performance**: We want to exceed or match the fastest ORMs in Python.
+- **Typehinting**: Everything should be typehinted with expected types.
+- **Postgres only**: Leverage native Postgres features and simplify the implementation.
+- **Common is easy, rare is possible**: If you're writing _really_ complex queries, these are better done by hand so you can see exactly what SQL will be run by.

--- a/iceaxe/__tests__/benchmarks/test_select.py
+++ b/iceaxe/__tests__/benchmarks/test_select.py
@@ -20,6 +20,7 @@ async def fetch_users_raw(conn: asyncpg.Connection) -> list[Any]:
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration_tests
 async def test_benchmark(db_connection: DBConnection, request):
     num_users = 500_000
     num_loops = 10

--- a/iceaxe/__tests__/conf_models.py
+++ b/iceaxe/__tests__/conf_models.py
@@ -12,6 +12,12 @@ class UserDemo(TableBase):
     email: str
 
 
+class ArtifactDemo(TableBase):
+    id: int = Field(primary_key=True, default=None)
+    title: str
+    user_id: int = Field(foreign_key="userdemo.id")
+
+
 @contextmanager
 def run_profile(request):
     TESTS_ROOT = Path.cwd()

--- a/iceaxe/__tests__/conftest.py
+++ b/iceaxe/__tests__/conftest.py
@@ -16,6 +16,10 @@ async def db_connection():
         )
     )
 
+    # Clear the old table from previous runs
+    await conn.conn.fetch("DROP TABLE IF EXISTS artifactdemo CASCADE")
+    await conn.conn.fetch("DROP TABLE IF EXISTS userdemo CASCADE")
+
     # Create a test table
     await conn.conn.fetch("""
         CREATE TABLE IF NOT EXISTS userdemo (
@@ -24,9 +28,17 @@ async def db_connection():
             email TEXT
         )
     """)
+
+    await conn.conn.fetch("""
+        CREATE TABLE IF NOT EXISTS artifactdemo (
+            id SERIAL PRIMARY KEY,
+            title TEXT,
+            user_id INT REFERENCES userdemo(id)
+        )
+        """)
+
     yield conn
     # Drop the test table after all tests
-    # await conn.conn.fetch("DROP TABLE IF EXISTS userdemo")
     await conn.conn.close()
 
 

--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -21,82 +21,82 @@ def db_field():
 def test_eq(db_field):
     result = db_field == 5
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.EQ
-    assert result.value == 5
+    assert result.right == 5
 
 
 def test_ne(db_field):
     result = db_field != 5
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.NE
-    assert result.value == 5
+    assert result.right == 5
 
 
 def test_lt(db_field):
     result = db_field < 5
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.LT
-    assert result.value == 5
+    assert result.right == 5
 
 
 def test_le(db_field):
     result = db_field <= 5
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.LE
-    assert result.value == 5
+    assert result.right == 5
 
 
 def test_gt(db_field):
     result = db_field > 5
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.GT
-    assert result.value == 5
+    assert result.right == 5
 
 
 def test_ge(db_field):
     result = db_field >= 5
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.GE
-    assert result.value == 5
+    assert result.right == 5
 
 
 def test_in(db_field):
     result = db_field.in_([1, 2, 3])
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.IN
-    assert result.value == [1, 2, 3]
+    assert result.right == [1, 2, 3]
 
 
 def test_not_in(db_field):
     result = db_field.not_in([1, 2, 3])
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.NOT_IN
-    assert result.value == [1, 2, 3]
+    assert result.right == [1, 2, 3]
 
 
 def test_contains(db_field):
     result = db_field.like("test")
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.LIKE
-    assert result.value == "test"
+    assert result.right == "test"
 
 
 # Test case for _compare method
 def test_compare(db_field):
     result = db_field._compare(ComparisonType.EQ, 10)
     assert isinstance(result, DBFieldClassComparison)
-    assert result.field == db_field
+    assert result.left == db_field
     assert result.comparison == ComparisonType.EQ
-    assert result.value == 10
+    assert result.right == 10
 
 
 # Test cases for edge cases and different types
@@ -127,23 +127,23 @@ def test_comparison_with_different_types(db_field, value):
         db_field.__ge__,
         db_field.in_,
         db_field.not_in,
-        db_field.contains,
+        db_field.like,
     ]:
         result = method(value)
         assert isinstance(result, DBFieldClassComparison)
-        assert result.field == db_field
+        assert result.left == db_field
         assert isinstance(result.comparison, ComparisonType)
-        assert result.value == value
+        assert result.right == value
 
 
 # Test case for DBFieldClassComparison instantiation
 def test_db_field_class_comparison_instantiation(db_field):
     comparison = DBFieldClassComparison(
-        field=db_field, comparison=ComparisonType.EQ, value=5
+        left=db_field, comparison=ComparisonType.EQ, right=5
     )
-    assert comparison.field == db_field
+    assert comparison.left == db_field
     assert comparison.comparison == ComparisonType.EQ
-    assert comparison.value == 5
+    assert comparison.right == 5
 
 
 # Test case for ComparisonType enum

--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -83,10 +83,10 @@ def test_not_in(db_field):
 
 
 def test_contains(db_field):
-    result = db_field.contains("test")
+    result = db_field.like("test")
     assert isinstance(result, DBFieldClassComparison)
     assert result.field == db_field
-    assert result.comparison == ComparisonType.CONTAINS
+    assert result.comparison == ComparisonType.LIKE
     assert result.value == "test"
 
 
@@ -156,7 +156,7 @@ def test_comparison_type_enum():
     assert ComparisonType.GE == ">="
     assert ComparisonType.IN == "IN"
     assert ComparisonType.NOT_IN == "NOT IN"
-    assert ComparisonType.CONTAINS == "CONTAINS"
+    assert ComparisonType.LIKE == "LIKE"
 
 
 # Test case for DBFieldClassDefinition instantiation

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -1,7 +1,8 @@
 import pytest
 
 from iceaxe.__tests__.conf_models import ArtifactDemo, UserDemo
-from iceaxe.queries import JoinType, OrderDirection, QueryBuilder, func
+from iceaxe.functions import func
+from iceaxe.queries import JoinType, OrderDirection, QueryBuilder
 
 
 def test_select():

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -1,5 +1,7 @@
-from iceaxe.__tests__.conf_models import UserDemo
-from iceaxe.queries import QueryBuilder
+import pytest
+
+from iceaxe.__tests__.conf_models import ArtifactDemo, UserDemo
+from iceaxe.queries import JoinType, OrderDirection, QueryBuilder, func
 
 
 def test_select():
@@ -10,6 +12,14 @@ def test_select():
 def test_select_single_field():
     new_query = QueryBuilder().select(UserDemo.email)
     assert new_query.build() == ('SELECT "userdemo"."email" FROM "userdemo"', [])
+
+
+def test_select_multiple_fields():
+    new_query = QueryBuilder().select((UserDemo.id, UserDemo.name, UserDemo.email))
+    assert new_query.build() == (
+        'SELECT "userdemo"."id", "userdemo"."name", "userdemo"."email" FROM "userdemo"',
+        [],
+    )
 
 
 def test_where():
@@ -28,3 +38,137 @@ def test_where_columns():
         'SELECT "userdemo"."id" FROM "userdemo" WHERE "userdemo"."name" = "userdemo"."email"',
         [],
     )
+
+
+def test_multiple_where_conditions():
+    new_query = (
+        QueryBuilder()
+        .select(UserDemo.id)
+        .where(UserDemo.id > 0, UserDemo.name == "John")
+    )
+    assert new_query.build() == (
+        'SELECT "userdemo"."id" FROM "userdemo" WHERE "userdemo"."id" > $1 AND "userdemo"."name" = $2',
+        [0, "John"],
+    )
+
+
+def test_order_by():
+    new_query = (
+        QueryBuilder().select(UserDemo.id).order_by(UserDemo.id, OrderDirection.DESC)
+    )
+    assert new_query.build() == (
+        'SELECT "userdemo"."id" FROM "userdemo" ORDER BY "userdemo"."id" DESC',
+        [],
+    )
+
+
+def test_multiple_order_by():
+    new_query = (
+        QueryBuilder()
+        .select(UserDemo.id)
+        .order_by(UserDemo.id, OrderDirection.DESC)
+        .order_by(UserDemo.name, OrderDirection.ASC)
+    )
+    assert new_query.build() == (
+        'SELECT "userdemo"."id" FROM "userdemo" ORDER BY "userdemo"."id" DESC, "userdemo"."name" ASC',
+        [],
+    )
+
+
+def test_join():
+    new_query = (
+        QueryBuilder()
+        .select((UserDemo.id, ArtifactDemo.title))
+        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id)
+    )
+    assert new_query.build() == (
+        'SELECT "userdemo"."id", "artifactdemo"."title" FROM "userdemo" INNER JOIN artifactdemo ON "userdemo"."id" = "artifactdemo"."user_id"',
+        [],
+    )
+
+
+def test_left_join():
+    new_query = (
+        QueryBuilder()
+        .select((UserDemo.id, ArtifactDemo.title))
+        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, JoinType.LEFT)
+    )
+    assert new_query.build() == (
+        'SELECT "userdemo"."id", "artifactdemo"."title" FROM "userdemo" LEFT JOIN artifactdemo ON "userdemo"."id" = "artifactdemo"."user_id"',
+        [],
+    )
+
+
+def test_limit():
+    new_query = QueryBuilder().select(UserDemo.id).limit(10)
+    assert new_query.build() == ('SELECT "userdemo"."id" FROM "userdemo" LIMIT 10', [])
+
+
+def test_offset():
+    new_query = QueryBuilder().select(UserDemo.id).offset(5)
+    assert new_query.build() == ('SELECT "userdemo"."id" FROM "userdemo" OFFSET 5', [])
+
+
+def test_limit_and_offset():
+    new_query = QueryBuilder().select(UserDemo.id).limit(10).offset(5)
+    assert new_query.build() == (
+        'SELECT "userdemo"."id" FROM "userdemo" LIMIT 10 OFFSET 5',
+        [],
+    )
+
+
+def test_group_by():
+    new_query = (
+        QueryBuilder()
+        .select((UserDemo.name, func.count(UserDemo.id)))
+        .group_by(UserDemo.name)
+    )
+    assert new_query.build() == (
+        'SELECT "userdemo"."name", count("userdemo"."id") AS aggregate_0 FROM "userdemo" GROUP BY "userdemo"."name"',
+        [],
+    )
+
+
+def test_update():
+    new_query = QueryBuilder().update(UserDemo).where(UserDemo.id == 1)
+    new_query.update_values = {"name": "New Name"}
+    assert new_query.build() == (
+        'UPDATE "userdemo" SET name = %s WHERE "userdemo"."id" = $1',
+        [1],
+    )
+
+
+def test_text():
+    new_query = QueryBuilder().text("SELECT * FROM users WHERE id = $1", 1)
+    assert new_query.build() == ("SELECT * FROM users WHERE id = $1", [1])
+
+
+def test_function_count():
+    new_query = QueryBuilder().select(func.count(UserDemo.id))
+    assert new_query.build() == (
+        'SELECT count("userdemo"."id") AS aggregate_0 FROM "userdemo"',
+        [],
+    )
+
+
+def test_function_distinct():
+    new_query = QueryBuilder().select(func.distinct(UserDemo.name))
+    assert new_query.build() == (
+        'SELECT distinct "userdemo"."name" AS aggregate_0 FROM "userdemo"',
+        [],
+    )
+
+
+def test_invalid_where_condition():
+    with pytest.raises(ValueError):
+        QueryBuilder().select(UserDemo.id).where("invalid condition")  # type: ignore
+
+
+def test_invalid_join_condition():
+    with pytest.raises(ValueError):
+        QueryBuilder().select(UserDemo.id).join(ArtifactDemo, "invalid condition")  # type: ignore
+
+
+def test_invalid_group_by():
+    with pytest.raises(ValueError):
+        QueryBuilder().select(UserDemo.id).group_by("invalid field")

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -1,27 +1,16 @@
 import pytest
 
 from iceaxe.__tests__.conf_models import ArtifactDemo, UserDemo
-from iceaxe.queries import QueryBuilder
+from iceaxe.functions import func
+from iceaxe.queries import JoinType, OrderDirection, QueryBuilder
 from iceaxe.session import (
     DBConnection,
 )
+from iceaxe.typing import col
 
-
-@pytest.mark.asyncio
-async def test_db_connection_exec(db_connection: DBConnection):
-    # Insert a test user
-    await db_connection.conn.fetch(
-        "INSERT INTO userdemo (name, email) VALUES ($1, $2)",
-        "Test User",
-        "test@example.com",
-    )
-
-    # Query the database
-    result = await db_connection.conn.fetch("SELECT * FROM userdemo")
-
-    assert len(result) == 1
-    assert result[0]["name"] == "Test User"
-    assert result[0]["email"] == "test@example.com"
+#
+# Insert / Update with ORM objects
+#
 
 
 @pytest.mark.asyncio
@@ -139,6 +128,11 @@ async def test_db_connection_update_no_modifications(db_connection: DBConnection
     assert result[0]["email"] == "john@example.com"
 
 
+#
+# Select into ORM objects
+#
+
+
 @pytest.mark.asyncio
 async def test_select(db_connection: DBConnection):
     user = UserDemo(name="John Doe", email="john@example.com")
@@ -204,3 +198,159 @@ async def test_select_join(db_connection: DBConnection):
             "john@example.com",
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_select_with_limit_and_offset(db_connection: DBConnection):
+    users = [
+        UserDemo(name="User 1", email="user1@example.com"),
+        UserDemo(name="User 2", email="user2@example.com"),
+        UserDemo(name="User 3", email="user3@example.com"),
+        UserDemo(name="User 4", email="user4@example.com"),
+        UserDemo(name="User 5", email="user5@example.com"),
+    ]
+    await db_connection.insert(users)
+
+    query = (
+        QueryBuilder()
+        .select(UserDemo)
+        .order_by(UserDemo.id, OrderDirection.ASC)
+        .limit(2)
+        .offset(1)
+    )
+    result = await db_connection.exec(query)
+    assert len(result) == 2
+    assert result[0].name == "User 2"
+    assert result[1].name == "User 3"
+
+
+@pytest.mark.asyncio
+async def test_select_with_multiple_where_conditions(db_connection: DBConnection):
+    users = [
+        UserDemo(name="John Doe", email="john@example.com"),
+        UserDemo(name="Jane Doe", email="jane@example.com"),
+        UserDemo(name="Bob Smith", email="bob@example.com"),
+    ]
+    await db_connection.insert(users)
+
+    query = (
+        QueryBuilder()
+        .select(UserDemo)
+        .where(col(UserDemo.name).like("%Doe%"), UserDemo.email != "john@example.com")
+    )
+    result = await db_connection.exec(query)
+    assert len(result) == 1
+    assert result[0].name == "Jane Doe"
+
+
+@pytest.mark.asyncio
+async def test_select_with_order_by_multiple_columns(db_connection: DBConnection):
+    users = [
+        UserDemo(name="Alice", email="alice@example.com"),
+        UserDemo(name="Bob", email="bob@example.com"),
+        UserDemo(name="Charlie", email="charlie@example.com"),
+        UserDemo(name="Alice", email="alice2@example.com"),
+    ]
+    await db_connection.insert(users)
+
+    query = (
+        QueryBuilder()
+        .select(UserDemo)
+        .order_by(UserDemo.name, OrderDirection.ASC)
+        .order_by(UserDemo.email, OrderDirection.ASC)
+    )
+    result = await db_connection.exec(query)
+    assert len(result) == 4
+    assert result[0].name == "Alice" and result[0].email == "alice2@example.com"
+    assert result[1].name == "Alice" and result[1].email == "alice@example.com"
+    assert result[2].name == "Bob"
+    assert result[3].name == "Charlie"
+
+
+@pytest.mark.asyncio
+async def test_select_with_group_by_and_having(db_connection: DBConnection):
+    users = [
+        UserDemo(name="John", email="john@example.com"),
+        UserDemo(name="Jane", email="jane@example.com"),
+        UserDemo(name="John", email="john2@example.com"),
+        UserDemo(name="Bob", email="bob@example.com"),
+    ]
+    await db_connection.insert(users)
+
+    query = (
+        QueryBuilder()
+        .select((UserDemo.name, func.count(UserDemo.id)))
+        .group_by(UserDemo.name)
+        .having(func.count(UserDemo.id) > 1)
+    )
+    result = await db_connection.exec(query)
+    assert len(result) == 1
+    assert result[0] == ("John", 2)
+
+
+@pytest.mark.asyncio
+async def test_select_with_left_join(db_connection: DBConnection):
+    users = [
+        UserDemo(name="John", email="john@example.com"),
+        UserDemo(name="Jane", email="jane@example.com"),
+    ]
+    await db_connection.insert(users)
+
+    posts = [
+        ArtifactDemo(title="John's Post", user_id=users[0].id),
+        ArtifactDemo(title="Another Post", user_id=users[0].id),
+    ]
+    await db_connection.insert(posts)
+
+    query = (
+        QueryBuilder()
+        .select((UserDemo.name, func.count(ArtifactDemo.id)))
+        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, JoinType.LEFT)
+        .group_by(UserDemo.name)
+        .order_by(UserDemo.name, OrderDirection.ASC)
+    )
+    result = await db_connection.exec(query)
+    assert len(result) == 2
+    assert result[0] == ("Jane", 0)
+    assert result[1] == ("John", 2)
+
+
+# @pytest.mark.asyncio
+# async def test_select_with_subquery(db_connection: DBConnection):
+#     users = [
+#         UserDemo(name="John", email="john@example.com"),
+#         UserDemo(name="Jane", email="jane@example.com"),
+#         UserDemo(name="Bob", email="bob@example.com"),
+#     ]
+#     await db_connection.insert(users)
+
+#     posts = [
+#         ArtifactDemo(title="John's Post", content="Hello", user_id=users[0].id),
+#         ArtifactDemo(title="Jane's Post", content="World", user_id=users[1].id),
+#         ArtifactDemo(title="John's Second Post", content="!", user_id=users[0].id),
+#     ]
+#     await db_connection.insert(posts)
+
+#     subquery = QueryBuilder().select(ArtifactDemo.user_id).where(func.count(ArtifactDemo.id) > 1).group_by(PostDemo.user_id)
+#     query = QueryBuilder().select(UserDemo).where(is_column(UserDemo.id).in_(subquery))
+#     result = await db_connection.exec(query)
+#     assert len(result) == 1
+#     assert result[0].name == "John"
+
+
+@pytest.mark.asyncio
+async def test_select_with_distinct(db_connection: DBConnection):
+    users = [
+        UserDemo(name="John", email="john@example.com"),
+        UserDemo(name="Jane", email="jane@example.com"),
+        UserDemo(name="John", email="john2@example.com"),
+    ]
+    await db_connection.insert(users)
+
+    query = (
+        QueryBuilder()
+        .select(func.distinct(UserDemo.name))
+        .order_by(UserDemo.name, OrderDirection.ASC)
+    )
+    result = await db_connection.exec(query)
+    assert result == ["Jane", "John"]

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -150,14 +150,14 @@ class DBFieldClassDefinition:
         return self._compare(ComparisonType.LIKE, other)  # type: ignore
 
     def _compare(self, comparison: ComparisonType, other: Any):
-        return DBFieldClassComparison(field=self, comparison=comparison, value=other)
+        return DBFieldClassComparison(left=self, comparison=comparison, right=other)
 
 
 @dataclass
 class DBFieldClassComparison:
-    field: DBFieldClassDefinition
+    left: DBFieldClassDefinition
     comparison: ComparisonType
-    value: DBFieldClassDefinition | Any
+    right: DBFieldClassDefinition | Any
 
 
 @dataclass_transform(kw_only_default=True, field_specifiers=(PydanticField,))

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -113,7 +113,7 @@ class ComparisonType(StrEnum):
     GE = ">="
     IN = "IN"
     NOT_IN = "NOT IN"
-    CONTAINS = "CONTAINS"
+    LIKE = "LIKE"
 
 
 @dataclass
@@ -140,14 +140,14 @@ class DBFieldClassDefinition:
     def __ge__(self, other):
         return self._compare(ComparisonType.GE, other)
 
-    def in_(self, other):
-        return self._compare(ComparisonType.IN, other)
+    def in_(self, other) -> bool:
+        return self._compare(ComparisonType.IN, other)  # type: ignore
 
-    def not_in(self, other):
-        return self._compare(ComparisonType.NOT_IN, other)
+    def not_in(self, other) -> bool:
+        return self._compare(ComparisonType.NOT_IN, other)  # type: ignore
 
-    def contains(self, other):
-        return self._compare(ComparisonType.CONTAINS, other)
+    def like(self, other) -> bool:
+        return self._compare(ComparisonType.LIKE, other)  # type: ignore
 
     def _compare(self, comparison: ComparisonType, other: Any):
         return DBFieldClassComparison(field=self, comparison=comparison, value=other)

--- a/iceaxe/functions.py
+++ b/iceaxe/functions.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypeVar, cast
+
+from iceaxe.base import (
+    ComparisonType,
+    DBFieldClassDefinition,
+)
+from iceaxe.queries import field_to_literal
+from iceaxe.queries_str import QueryLiteral
+from iceaxe.typing import is_column, is_function_metadata
+
+T = TypeVar("T")
+
+
+@dataclass
+class FunctionMetadataComparison:
+    left: FunctionMetadata
+    comparison: ComparisonType
+    right: FunctionMetadata | Any
+
+
+@dataclass
+class FunctionMetadata:
+    literal: QueryLiteral
+    original_field: DBFieldClassDefinition
+    local_name: str | None = None
+
+    def __eq__(self, other):  # type: ignore
+        return self._compare(ComparisonType.EQ, other)
+
+    def __ne__(self, other):  # type: ignore
+        return self._compare(ComparisonType.NE, other)
+
+    def __lt__(self, other):
+        return self._compare(ComparisonType.LT, other)
+
+    def __le__(self, other):
+        return self._compare(ComparisonType.LE, other)
+
+    def __gt__(self, other):
+        return self._compare(ComparisonType.GT, other)
+
+    def __ge__(self, other):
+        return self._compare(ComparisonType.GE, other)
+
+    def in_(self, other) -> bool:
+        return self._compare(ComparisonType.IN, other)  # type: ignore
+
+    def not_in(self, other) -> bool:
+        return self._compare(ComparisonType.NOT_IN, other)  # type: ignore
+
+    def like(self, other) -> bool:
+        return self._compare(ComparisonType.LIKE, other)  # type: ignore
+
+    def _compare(self, comparison: ComparisonType, other: Any):
+        return FunctionMetadataComparison(left=self, comparison=comparison, right=other)
+
+
+class FunctionBuilder:
+    def count(self, field: Any) -> int:
+        metadata = self._column_to_metadata(field)
+        metadata.literal = QueryLiteral(f"count({metadata.literal})")
+        return cast(int, metadata)
+
+    def distinct(self, field: T) -> T:
+        metadata = self._column_to_metadata(field)
+        metadata.literal = QueryLiteral(f"distinct {metadata.literal}")
+        return cast(T, metadata)
+
+    def sum(self, field: T) -> T:
+        metadata = self._column_to_metadata(field)
+        metadata.literal = QueryLiteral(f"sum({metadata.literal})")
+        return cast(T, metadata)
+
+    def avg(self, field: T) -> T:
+        metadata = self._column_to_metadata(field)
+        metadata.literal = QueryLiteral(f"avg({metadata.literal})")
+        return cast(T, metadata)
+
+    def max(self, field: T) -> T:
+        metadata = self._column_to_metadata(field)
+        metadata.literal = QueryLiteral(f"max({metadata.literal})")
+        return cast(T, metadata)
+
+    def min(self, field: T) -> T:
+        metadata = self._column_to_metadata(field)
+        metadata.literal = QueryLiteral(f"min({metadata.literal})")
+        return cast(T, metadata)
+
+    def _column_to_metadata(self, field: Any) -> FunctionMetadata:
+        if is_function_metadata(field):
+            return field
+        elif is_column(field):
+            return FunctionMetadata(
+                literal=field_to_literal(field), original_field=field
+            )
+        else:
+            raise ValueError(
+                f"Unable to cast this type to a column: {field} ({type(field)})"
+            )
+
+
+func = FunctionBuilder()

--- a/iceaxe/functions.py
+++ b/iceaxe/functions.py
@@ -7,8 +7,7 @@ from iceaxe.base import (
     ComparisonType,
     DBFieldClassDefinition,
 )
-from iceaxe.queries import field_to_literal
-from iceaxe.queries_str import QueryLiteral
+from iceaxe.queries_str import QueryLiteral, field_to_literal
 from iceaxe.typing import is_column, is_function_metadata
 
 T = TypeVar("T")

--- a/iceaxe/queries_str.py
+++ b/iceaxe/queries_str.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from iceaxe.base import (
+    DBFieldClassDefinition,
+)
+
+
+class QueryElementBase(ABC):
+    def __init__(self, value: str):
+        self._value = self.process_value(value)
+
+    @abstractmethod
+    def process_value(self, value: str) -> str:
+        pass
+
+    def __str__(self):
+        return self._value
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._value})"
+
+
+class QueryIdentifier(QueryElementBase):
+    def process_value(self, value: str):
+        return f'"{value}"'
+
+
+class QueryLiteral(QueryElementBase):
+    def process_value(self, value: str):
+        return value
+
+
+def field_to_literal(field: DBFieldClassDefinition) -> QueryLiteral:
+    table = QueryIdentifier(field.root_model.get_table_name())
+    column = QueryIdentifier(field.key)
+    return QueryLiteral(f"{table}.{column}")

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from inspect import isclass
+from typing import Any, TypeGuard
+
+from iceaxe.base import (
+    DBFieldClassComparison,
+    DBFieldClassDefinition,
+    TableBase,
+)
+from iceaxe.functions import FunctionMetadata
+from iceaxe.queries_str import QueryLiteral
+
+
+def is_base_table(obj: Any) -> TypeGuard[type[TableBase]]:
+    return isclass(obj) and issubclass(obj, TableBase)
+
+
+def is_column(obj: Any) -> TypeGuard[DBFieldClassDefinition]:
+    return isinstance(obj, DBFieldClassDefinition)
+
+
+def is_comparison(obj: Any) -> TypeGuard[DBFieldClassComparison]:
+    return isinstance(obj, DBFieldClassComparison)
+
+
+def is_literal(obj: Any) -> TypeGuard[QueryLiteral]:
+    return isinstance(obj, QueryLiteral)
+
+
+def is_function_metadata(obj: Any) -> TypeGuard[FunctionMetadata]:
+    return isinstance(obj, FunctionMetadata)
+
+
+def col(obj: Any):
+    if not is_column(obj):
+        raise ValueError(f"Invalid column: {obj}")
+    return obj

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -1,35 +1,52 @@
 from __future__ import annotations
 
 from inspect import isclass
-from typing import Any, TypeGuard
+from typing import TYPE_CHECKING, Any, TypeGuard
 
-from iceaxe.base import (
-    DBFieldClassComparison,
-    DBFieldClassDefinition,
-    TableBase,
-)
-from iceaxe.functions import FunctionMetadata
-from iceaxe.queries_str import QueryLiteral
+if TYPE_CHECKING:
+    from iceaxe.base import (
+        DBFieldClassComparison,
+        DBFieldClassDefinition,
+        TableBase,
+    )
+    from iceaxe.functions import FunctionMetadata, FunctionMetadataComparison
+    from iceaxe.queries_str import QueryLiteral
 
 
 def is_base_table(obj: Any) -> TypeGuard[type[TableBase]]:
+    from iceaxe.base import TableBase
+
     return isclass(obj) and issubclass(obj, TableBase)
 
 
 def is_column(obj: Any) -> TypeGuard[DBFieldClassDefinition]:
+    from iceaxe.base import DBFieldClassDefinition
+
     return isinstance(obj, DBFieldClassDefinition)
 
 
 def is_comparison(obj: Any) -> TypeGuard[DBFieldClassComparison]:
+    from iceaxe.base import DBFieldClassComparison
+
     return isinstance(obj, DBFieldClassComparison)
 
 
 def is_literal(obj: Any) -> TypeGuard[QueryLiteral]:
+    from iceaxe.queries_str import QueryLiteral
+
     return isinstance(obj, QueryLiteral)
 
 
 def is_function_metadata(obj: Any) -> TypeGuard[FunctionMetadata]:
+    from iceaxe.functions import FunctionMetadata
+
     return isinstance(obj, FunctionMetadata)
+
+
+def is_function_metadata_comparison(obj: Any) -> TypeGuard[FunctionMetadataComparison]:
+    from iceaxe.functions import FunctionMetadataComparison
+
+    return isinstance(obj, FunctionMetadataComparison)
 
 
 def col(obj: Any):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ pyinstrument = "^4.7.3"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.pytest.ini_options]
+markers = ["integration_tests: run longer-running integration tests"]
+# Default pytest runs shouldn't execute the integration tests
+addopts = "-m 'not integration_tests'"
+
 [tool.mypy]
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
- Add support for customizing joins across tables

```python
new_query = (
        QueryBuilder()
        .select((UserDemo.id, ArtifactDemo.title))
        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id)
    )
```

- Support fetching the value of function outputs. Since these are normally un-named, we need to assign them a temporary attribute title so our fetch pipeline can extract the values.
- Add additional tests for query construction and expected output
- Refactor longer running tests (benchmarking script) into integration tests

Integration tests are executed by:

```bash
poetry run pytest -v --continue-on-collection-errors -m integration_tests
```