### PR TITLE
Add support for datetime fields in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,4 +217,5 @@ network connections in the first place.
 
 ## TODOs
 
+- [ ] Properly resolve select(Type[TableBase]) to return an instance of TableBase.
 - [ ] Additional documentation with usage examples.

--- a/iceaxe/__init__.py
+++ b/iceaxe/__init__.py
@@ -1,3 +1,5 @@
 from .base import Field as Field, TableBase as TableBase
+from .functions import func as func
+from .postgres import PostgresDateTime as PostgresDateTime, PostgresTime as PostgresTime
 from .queries import QueryBuilder as QueryBuilder, select as select, update as update
 from .session import DBConnection as DBConnection

--- a/iceaxe/__init__.py
+++ b/iceaxe/__init__.py
@@ -3,3 +3,4 @@ from .functions import func as func
 from .postgres import PostgresDateTime as PostgresDateTime, PostgresTime as PostgresTime
 from .queries import QueryBuilder as QueryBuilder, select as select, update as update
 from .session import DBConnection as DBConnection
+from .typing import column as column

--- a/iceaxe/__tests__/migrations/test_db_serializer.py
+++ b/iceaxe/__tests__/migrations/test_db_serializer.py
@@ -21,18 +21,6 @@ from iceaxe.migrations.db_stubs import (
 from iceaxe.session import DBConnection
 
 
-class ValueEnumStandard(Enum):
-    A = "A"
-
-
-class ValueEnumStr(StrEnum):
-    A = "A"
-
-
-class ValueEnumInt(IntEnum):
-    A = 1
-
-
 def compare_db_objects(
     calculated: list[tuple[DBObject, list[DBObject | DBObjectPointer]]],
     expected: list[tuple[DBObject, list[DBObject | DBObjectPointer]]],
@@ -46,6 +34,18 @@ def compare_db_objects(
     assert sorted(calculated, key=lambda x: x[0].representation()) == sorted(
         expected, key=lambda x: x[0].representation()
     )
+
+
+class ValueEnumStandard(Enum):
+    A = "A"
+
+
+class ValueEnumStr(StrEnum):
+    A = "A"
+
+
+class ValueEnumInt(IntEnum):
+    A = 1
 
 
 @pytest.mark.asyncio

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -2,7 +2,7 @@ import pytest
 
 from iceaxe.__tests__.conf_models import ArtifactDemo, UserDemo
 from iceaxe.functions import func
-from iceaxe.queries import JoinType, OrderDirection, QueryBuilder
+from iceaxe.queries import QueryBuilder
 
 
 def test_select():
@@ -54,9 +54,7 @@ def test_multiple_where_conditions():
 
 
 def test_order_by():
-    new_query = (
-        QueryBuilder().select(UserDemo.id).order_by(UserDemo.id, OrderDirection.DESC)
-    )
+    new_query = QueryBuilder().select(UserDemo.id).order_by(UserDemo.id, "DESC")
     assert new_query.build() == (
         'SELECT "userdemo"."id" FROM "userdemo" ORDER BY "userdemo"."id" DESC',
         [],
@@ -67,8 +65,8 @@ def test_multiple_order_by():
     new_query = (
         QueryBuilder()
         .select(UserDemo.id)
-        .order_by(UserDemo.id, OrderDirection.DESC)
-        .order_by(UserDemo.name, OrderDirection.ASC)
+        .order_by(UserDemo.id, "DESC")
+        .order_by(UserDemo.name, "ASC")
     )
     assert new_query.build() == (
         'SELECT "userdemo"."id" FROM "userdemo" ORDER BY "userdemo"."id" DESC, "userdemo"."name" ASC',
@@ -92,7 +90,7 @@ def test_left_join():
     new_query = (
         QueryBuilder()
         .select((UserDemo.id, ArtifactDemo.title))
-        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, JoinType.LEFT)
+        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, "LEFT")
     )
     assert new_query.build() == (
         'SELECT "userdemo"."id", "artifactdemo"."title" FROM "userdemo" LEFT JOIN artifactdemo ON "userdemo"."id" = "artifactdemo"."user_id"',

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -2,11 +2,11 @@ import pytest
 
 from iceaxe.__tests__.conf_models import ArtifactDemo, UserDemo
 from iceaxe.functions import func
-from iceaxe.queries import JoinType, OrderDirection, QueryBuilder
+from iceaxe.queries import QueryBuilder
 from iceaxe.session import (
     DBConnection,
 )
-from iceaxe.typing import col
+from iceaxe.typing import column
 
 #
 # Insert / Update with ORM objects
@@ -212,11 +212,7 @@ async def test_select_with_limit_and_offset(db_connection: DBConnection):
     await db_connection.insert(users)
 
     query = (
-        QueryBuilder()
-        .select(UserDemo)
-        .order_by(UserDemo.id, OrderDirection.ASC)
-        .limit(2)
-        .offset(1)
+        QueryBuilder().select(UserDemo).order_by(UserDemo.id, "ASC").limit(2).offset(1)
     )
     result = await db_connection.exec(query)
     assert len(result) == 2
@@ -236,7 +232,9 @@ async def test_select_with_multiple_where_conditions(db_connection: DBConnection
     query = (
         QueryBuilder()
         .select(UserDemo)
-        .where(col(UserDemo.name).like("%Doe%"), UserDemo.email != "john@example.com")
+        .where(
+            column(UserDemo.name).like("%Doe%"), UserDemo.email != "john@example.com"
+        )
     )
     result = await db_connection.exec(query)
     assert len(result) == 1
@@ -256,8 +254,8 @@ async def test_select_with_order_by_multiple_columns(db_connection: DBConnection
     query = (
         QueryBuilder()
         .select(UserDemo)
-        .order_by(UserDemo.name, OrderDirection.ASC)
-        .order_by(UserDemo.email, OrderDirection.ASC)
+        .order_by(UserDemo.name, "ASC")
+        .order_by(UserDemo.email, "ASC")
     )
     result = await db_connection.exec(query)
     assert len(result) == 4
@@ -305,9 +303,9 @@ async def test_select_with_left_join(db_connection: DBConnection):
     query = (
         QueryBuilder()
         .select((UserDemo.name, func.count(ArtifactDemo.id)))
-        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, JoinType.LEFT)
+        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, "LEFT")
         .group_by(UserDemo.name)
-        .order_by(UserDemo.name, OrderDirection.ASC)
+        .order_by(UserDemo.name, "ASC")
     )
     result = await db_connection.exec(query)
     assert len(result) == 2
@@ -350,7 +348,7 @@ async def test_select_with_distinct(db_connection: DBConnection):
     query = (
         QueryBuilder()
         .select(func.distinct(UserDemo.name))
-        .order_by(UserDemo.name, OrderDirection.ASC)
+        .order_by(UserDemo.name, "ASC")
     )
     result = await db_connection.exec(query)
     assert result == ["Jane", "John"]

--- a/iceaxe/migrations/__init__.py
+++ b/iceaxe/migrations/__init__.py
@@ -1,0 +1,5 @@
+from .cli import (
+    handle_apply as handle_apply,
+    handle_generate as handle_generate,
+    handle_rollback as handle_rollback,
+)

--- a/iceaxe/mountaineer/__init__.py
+++ b/iceaxe/mountaineer/__init__.py
@@ -1,3 +1,10 @@
 from iceaxe.mountaineer import (
     dependencies as DatabaseDependencies,  # noqa: F401
 )
+
+from .cli import (
+    apply_migration as apply_migration,
+    generate_migration as generate_migration,
+    rollback_migration as rollback_migration,
+)
+from .config import DatabaseConfig as DatabaseConfig

--- a/iceaxe/mountaineer/__init__.py
+++ b/iceaxe/mountaineer/__init__.py
@@ -1,0 +1,3 @@
+from iceaxe.mountaineer import (
+    dependencies as DatabaseDependencies,  # noqa: F401
+)

--- a/iceaxe/mountaineer/dependencies/__init__.py
+++ b/iceaxe/mountaineer/dependencies/__init__.py
@@ -1,0 +1,6 @@
+"""
+Database dependencies for use in API endpoint routes.
+
+"""
+
+from .core import get_db_connection as get_db_connection

--- a/iceaxe/postgres.py
+++ b/iceaxe/postgres.py
@@ -13,3 +13,7 @@ class PostgresFieldBase(BaseModel):
 
 class PostgresDateTime(PostgresFieldBase):
     timezone: bool = False
+
+
+class PostgresTime(PostgresFieldBase):
+    timezone: bool = False

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import Any, Generic, Literal, Type, TypeVar
 
 from iceaxe.base import (
@@ -29,16 +28,8 @@ P = TypeVar("P")
 QueryType = TypeVar("QueryType", bound=Literal["SELECT", "INSERT", "UPDATE", "DELETE"])
 
 
-class JoinType(Enum):
-    INNER = "INNER"
-    LEFT = "LEFT"
-    RIGHT = "RIGHT"
-    FULL = "FULL"
-
-
-class OrderDirection(Enum):
-    ASC = "ASC"
-    DESC = "DESC"
+JoinType = Literal["INNER", "LEFT", "RIGHT", "FULL"]
+OrderDirection = Literal["ASC", "DESC"]
 
 
 class QueryBuilder(Generic[P, QueryType]):
@@ -148,17 +139,15 @@ class QueryBuilder(Generic[P, QueryType]):
         self.where_conditions += validated_comparisons
         return self
 
-    def order_by(self, field: Any, direction: OrderDirection = OrderDirection.ASC):
+    def order_by(self, field: Any, direction: OrderDirection = "ASC"):
         if not is_column(field):
             raise ValueError(f"Invalid order by field: {field}")
 
         field_token = field_to_literal(field)
-        self.order_by_clauses.append(f"{field_token} {direction.value}")
+        self.order_by_clauses.append(f"{field_token} {direction}")
         return self
 
-    def join(
-        self, table: Type[TableBase], on: bool, join_type: JoinType = JoinType.INNER
-    ):
+    def join(self, table: Type[TableBase], on: bool, join_type: JoinType = "INNER"):
         if not is_comparison(on):
             raise ValueError(
                 f"Invalid join condition: {on}, should be MyTable.column == OtherTable.column"
@@ -169,9 +158,7 @@ class QueryBuilder(Generic[P, QueryType]):
         comparison = QueryLiteral(on.comparison.value)
         on_right = field_to_literal(on.right)
 
-        join_sql = (
-            f"{join_type.value} JOIN {table_name} ON {on_left} {comparison} {on_right}"
-        )
+        join_sql = f"{join_type} JOIN {table_name} ON {on_left} {comparison} {on_right}"
         self.join_clauses.append(join_sql)
         return self
 

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -49,7 +49,7 @@ def is_function_metadata_comparison(obj: Any) -> TypeGuard[FunctionMetadataCompa
     return isinstance(obj, FunctionMetadataComparison)
 
 
-def col(obj: Any):
+def column(obj: Any):
     if not is_column(obj):
         raise ValueError(f"Invalid column: {obj}")
     return obj


### PR DESCRIPTION
Add migration support for specifying `datetime`, `date`, `time`, and `timedelta` within the table declarations. To configure these values to use a timezone you can use the `PostgresDateTime` classes as the `postgres_config` parameter:

```python
from iceaxe import Field, TableBase, PostgresDateTime

class Job(TableBase):
  id: int = Field()
  created_at: datetime = Field(postgres_config=PostgresDateTime(timezone=True))
```