### PR TITLE
Resolve class TableBase queries into instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,6 @@ define lint-common
 	echo "Running linting for $(2)..."
 	@(cd $(1) && poetry run ruff format $(2))
 	@(cd $(1) && poetry run ruff check --fix $(2))
-	echo "Running mypy for $(2)..."
-	@(cd $(1) && poetry run mypy $(2))
 	echo "Running pyright for $(2)..."
 	@(cd $(1) && poetry run pyright $(2))
 endef

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -1,8 +1,10 @@
+from typing import TYPE_CHECKING, Literal
+
 import pytest
 
 from iceaxe.__tests__.conf_models import ArtifactDemo, UserDemo
 from iceaxe.functions import func
-from iceaxe.queries import QueryBuilder
+from iceaxe.queries import QueryBuilder, select
 
 
 def test_select():
@@ -171,3 +173,22 @@ def test_invalid_join_condition():
 def test_invalid_group_by():
     with pytest.raises(ValueError):
         QueryBuilder().select(UserDemo.id).group_by("invalid field")
+
+
+#
+# Typehinting
+# These checks are run as part of the static typechecking we do
+# for our codebase, not as part of the pytest runtime.
+#
+
+
+def test_select_single_typehint():
+    query = select(UserDemo)
+    if TYPE_CHECKING:
+        _: QueryBuilder[UserDemo, Literal["SELECT"]] = query
+
+
+def test_select_multiple_typehints():
+    query = select((UserDemo, UserDemo.id, UserDemo.name))
+    if TYPE_CHECKING:
+        _: QueryBuilder[tuple[UserDemo, int, str], Literal["SELECT"]] = query

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Literal, Type, TypeVar, TypeVarTuple, Unpack, overload
+from typing import Any, Generic, Literal, Type, TypeVar, TypeVarTuple, overload
 
 from iceaxe.base import (
     DBFieldClassComparison,
     DBFieldClassDefinition,
+    DBModelMetaclass,
     TableBase,
 )
 from iceaxe.functions import FunctionMetadata, FunctionMetadataComparison
@@ -32,6 +33,7 @@ P = TypeVar("P")
 T = TypeVar(
     "T",
     bound=TableBase
+    | DBModelMetaclass
     | ALL_ENUM_TYPES
     | PRIMITIVE_TYPES
     | PRIMITIVE_WRAPPER_TYPES
@@ -39,9 +41,6 @@ T = TypeVar(
     | JSON_WRAPPER_FALLBACK,
 )
 Ts = TypeVarTuple("Ts")
-
-ExecTupleInput = Unpack[tuple[T | Type[T], *Ts]]
-ExecTupleOutput = tuple[T, *Ts]
 
 
 QueryType = TypeVar("QueryType", bound=Literal["SELECT", "INSERT", "UPDATE", "DELETE"])
@@ -319,7 +318,21 @@ class QueryBuilder(Generic[P, QueryType]):
 #
 
 
-def select(fields: T) -> QueryBuilder[T, Literal["SELECT"]]:
+@overload
+def select(fields: T | Type[T]) -> QueryBuilder[T, Literal["SELECT"]]: ...
+
+
+@overload
+def select(
+    fields: tuple[T | Type[T], *Ts],
+) -> QueryBuilder[tuple[T, *Ts], Literal["SELECT"]]: ...
+
+
+def select(
+    fields: T | Type[T] | tuple[T | Type[T], *Ts],
+) -> (
+    QueryBuilder[tuple[T, *Ts], Literal["SELECT"]] | QueryBuilder[T, Literal["SELECT"]]
+):
     return QueryBuilder().select(fields)
 
 

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Literal, Type, TypeVar
+from typing import Any, Generic, Literal, Type, TypeVar, TypeVarTuple, Unpack, overload
 
 from iceaxe.base import (
     DBFieldClassComparison,
@@ -15,6 +15,11 @@ from iceaxe.queries_str import (
     field_to_literal,
 )
 from iceaxe.typing import (
+    ALL_ENUM_TYPES,
+    DATE_TYPES,
+    JSON_WRAPPER_FALLBACK,
+    PRIMITIVE_TYPES,
+    PRIMITIVE_WRAPPER_TYPES,
     is_base_table,
     is_column,
     is_comparison,
@@ -22,8 +27,22 @@ from iceaxe.typing import (
     is_function_metadata_comparison,
 )
 
-T = TypeVar("T")
 P = TypeVar("P")
+
+T = TypeVar(
+    "T",
+    bound=TableBase
+    | ALL_ENUM_TYPES
+    | PRIMITIVE_TYPES
+    | PRIMITIVE_WRAPPER_TYPES
+    | DATE_TYPES
+    | JSON_WRAPPER_FALLBACK,
+)
+Ts = TypeVarTuple("Ts")
+
+ExecTupleInput = Unpack[tuple[T | Type[T], *Ts]]
+ExecTupleOutput = tuple[T, *Ts]
+
 
 QueryType = TypeVar("QueryType", bound=Literal["SELECT", "INSERT", "UPDATE", "DELETE"])
 
@@ -59,14 +78,27 @@ class QueryBuilder(Generic[P, QueryType]):
         self.text_query: str | None = None
         self.text_variables: list[Any] = []
 
-    def select(self, fields: T) -> QueryBuilder[T, Literal["SELECT"]]:
+    @overload
+    def select(self, fields: T | Type[T]) -> QueryBuilder[T, Literal["SELECT"]]: ...
+
+    @overload
+    def select(
+        self, fields: tuple[T | Type[T], *Ts]
+    ) -> QueryBuilder[tuple[T, *Ts], Literal["SELECT"]]: ...
+
+    def select(
+        self, fields: T | Type[T] | tuple[T | Type[T], *Ts]
+    ) -> (
+        QueryBuilder[tuple[T, *Ts], Literal["SELECT"]]
+        | QueryBuilder[T, Literal["SELECT"]]
+    ):
         all_fields: tuple[
             DBFieldClassDefinition | Type[TableBase] | FunctionMetadata, ...
         ]
         if not isinstance(fields, tuple):
             all_fields = (fields,)  # type: ignore
         else:
-            all_fields = fields
+            all_fields = fields  # type: ignore
 
         # Verify the field type
         for field in all_fields:

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+from datetime import date, datetime, time, timedelta
+from enum import Enum, IntEnum, StrEnum
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, TypeGuard
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Type,
+    TypeGuard,
+)
+from uuid import UUID
 
 if TYPE_CHECKING:
     from iceaxe.base import (
@@ -11,6 +19,13 @@ if TYPE_CHECKING:
     )
     from iceaxe.functions import FunctionMetadata, FunctionMetadataComparison
     from iceaxe.queries_str import QueryLiteral
+
+
+ALL_ENUM_TYPES = Type[Enum | StrEnum | IntEnum]
+PRIMITIVE_TYPES = int | float | str | bool | bytes | UUID
+PRIMITIVE_WRAPPER_TYPES = list[PRIMITIVE_TYPES] | PRIMITIVE_TYPES
+DATE_TYPES = datetime | date | time | timedelta
+JSON_WRAPPER_FALLBACK = list[Any] | dict[Any, Any]
 
 
 def is_base_table(obj: Any) -> TypeGuard[type[TableBase]]:

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -68,3 +68,7 @@ def column(obj: Any):
     if not is_column(obj):
         raise ValueError(f"Invalid column: {obj}")
     return obj
+
+
+class MyObj:
+    pass


### PR DESCRIPTION
Previously our `select` queries were just echoing back the same exact type signature that we requested as input. If we requested a single object, that's what we'd get back. A tuple, that's similarly what we'd get back. This worked for column fields themselves since these are already typehinted as their final values, but the approach doesn't work for the TableBase instances themselves. When we request a selection we only have access to the model class itself. This is technically a Type[MyTable]. So we would inadvertently typehint the resulting payload as a class instead of values of that class.

We fix that here through more explicit typehinting at the selection stage. These are passed through to exec so no changes to the DBConnection is required.

### Ecosystem compatibility

Mypy appears to struggle on inferring these typehints. Pyright resolves the correct output: list[UserDemo] by passing through from the select to the exec.

```python
@pytest.mark.asyncio
async def test_select(db_connection: DBConnection):
    user = UserDemo(name="John Doe", email="john@example.com")
    await db_connection.insert([user])

    # Table selection
    result_1 = await db_connection.exec(QueryBuilder().select(UserDemo))
    assert result_1 == [UserDemo(id=user.id, name="John Doe", email="john@example.com")]

```

```
iceaxe/__tests__/test_session.py:142: error: Need type annotation for "result_1" (hint: "result_1: list[<type>] = ...")  [var-annotated]
iceaxe/__tests__/test_session.py:142: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "type[UserDemo]"; expected "type[Never]"  [arg-type]
iceaxe/__tests__/test_session.py:156: error: Need type annotation for "result_4"  [var-annotated]
iceaxe/__tests__/test_session.py:157: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "tuple[type[UserDemo], str]"; expected "tuple[type[Never], str]"  [arg-type]
iceaxe/__tests__/test_session.py:172: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "type[UserDemo]"; expected "type[Never]"  [arg-type]
iceaxe/__tests__/test_session.py:190: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "tuple[type[ArtifactDemo], str]"; expected "tuple[type[Never], str]"  [arg-type]
iceaxe/__tests__/test_session.py:215: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "type[UserDemo]"; expected "type[Never]"  [arg-type]
iceaxe/__tests__/test_session.py:234: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "type[UserDemo]"; expected "type[Never]"  [arg-type]
iceaxe/__tests__/test_session.py:256: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "type[UserDemo]"; expected "type[Never]"  [arg-type]
iceaxe/__tests__/test_queries.py:11: error: Need type annotation for "new_query"  [var-annotated]
iceaxe/__tests__/test_queries.py:11: error: Argument 1 to "select" of "QueryBuilder" has incompatible type "type[UserDemo]"; expected "type[Never]"  [arg-type]
iceaxe/__tests__/test_queries.py:186: error: Need type annotation for "query"  [var-annotated]
iceaxe/__tests__/test_queries.py:186: error: Argument 1 to "select" has incompatible type "type[UserDemo]"; expected "type[Never]"  [arg-type]
iceaxe/__tests__/test_queries.py:192: error: Need type annotation for "query"  [var-annotated]
iceaxe/__tests__/test_queries.py:192: error: Argument 1 to "select" has incompatible type "tuple[type[UserDemo], int, str]"; expected "tuple[type[Never], int, str]"  [arg-type]
Found 15 errors in 2 files (checked 42 source files)
```

We should follow up with a bug triage / post an issue in upstream to track.