### PR TITLE
Group migration objects by table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ to be as close as possible to raw-[asyncpg](https://github.com/MagicStack/asyncp
 expect in Python and it should bidirectionally sync to the database.
 - 🐘 **Postgres only**: Leverage native Postgres features and simplify the implementation.
 - ⚡ **Common things are easy, rare things are possible**: 99% of the SQL queries we write are
-vanilla SELECT/INSERT/UPDATEs. If you're writing _really_ complex queries, these are better
-done by hand so you can see exactly what SQL will be run by.
+vanilla SELECT/INSERT/UPDATEs. These should be natively supported by your ORM. If you're writing _really_
+complex queries, these are better done by hand so you can see exactly what SQL will be run.
 
 Iceaxe is in early alpha. It's also an independent project. It's compatible with the [Mountaineer](https://github.com/piercefreeman/mountaineer) ecosystem, but you can use it in whatever
 project and web framework you're using.
@@ -217,5 +217,4 @@ network connections in the first place.
 
 ## TODOs
 
-- [ ] Properly resolve select(Type[TableBase]) to return an instance of TableBase.
 - [ ] Additional documentation with usage examples.

--- a/iceaxe/__tests__/migrations/test_action_sorter.py
+++ b/iceaxe/__tests__/migrations/test_action_sorter.py
@@ -1,0 +1,235 @@
+import pytest
+
+from iceaxe.migrations.action_sorter import ActionTopologicalSorter
+from iceaxe.migrations.actions import DatabaseActions
+from iceaxe.migrations.db_stubs import DBObject
+
+
+class MockNode(DBObject):
+    name: str
+    table_name: str = "None"
+
+    model_config = {
+        "frozen": True,
+    }
+
+    def representation(self):
+        return f"MockNode({self.name}, {self.table_name})"
+
+    async def create(self, actor: DatabaseActions):
+        pass
+
+    async def migrate(self, previous: "MockNode", actor: DatabaseActions):
+        pass
+
+    async def destroy(self, actor: DatabaseActions):
+        pass
+
+    def __hash__(self):
+        return hash(self.representation())
+
+
+def custom_topological_sort(graph_edges):
+    sorter = ActionTopologicalSorter(graph_edges)
+    sorted_objects = sorter.sort()
+    return {obj: i for i, obj in enumerate(sorted_objects)}
+
+
+def test_simple_dag():
+    A = MockNode(name="A")
+    B = MockNode(name="B")
+    C = MockNode(name="C")
+    D = MockNode(name="D")
+    graph = {D: [B, C], C: [A], B: [A], A: []}
+    result = custom_topological_sort(graph)
+    assert list(result.keys()) == [A, B, C, D]
+
+
+def test_disconnected_graph():
+    A = MockNode(name="A")
+    B = MockNode(name="B")
+    C = MockNode(name="C")
+    D = MockNode(name="D")
+    E = MockNode(name="E")
+    graph = {B: [A], A: [], D: [C], C: [], E: []}
+    result = custom_topological_sort(graph)
+    assert set(result.keys()) == {A, B, C, D, E}
+    assert result[A] < result[B]
+    assert result[C] < result[D]
+
+
+def test_single_table_grouping():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B", table_name="table1")
+    C = MockNode(name="C", table_name="table1")
+    graph = {C: [], B: [C], A: [B]}
+    result = custom_topological_sort(graph)
+    assert list(result.keys()) == [C, B, A]
+
+
+def test_multiple_table_grouping():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B", table_name="table1")
+    C = MockNode(name="C", table_name="table2")
+    D = MockNode(name="D", table_name="table2")
+    E = MockNode(name="E", table_name="table3")
+    graph = {E: [], D: [], C: [D, E], A: [C], B: [C]}
+    result = custom_topological_sort(graph)
+    assert set(result.keys()) == {A, B, C, D, E}
+    assert result[C] < result[A] and result[C] < result[B]
+    assert result[D] < result[C] and result[E] < result[C]
+
+
+def test_cross_table_references():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B", table_name="table2")
+    C = MockNode(name="C", table_name="table1")
+    D = MockNode(name="D", table_name="table2")
+    graph = {D: [], C: [D], B: [C], A: [B]}
+    result = custom_topological_sort(graph)
+    assert list(result.keys()) == [D, C, B, A]
+
+
+def test_nodes_without_table_name():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B")
+    C = MockNode(name="C", table_name="table2")
+    D = MockNode(name="D")
+    graph = {D: [], C: [D], B: [C], A: [B]}
+    result = custom_topological_sort(graph)
+    assert list(result.keys()) == [D, C, B, A]
+
+
+def test_complex_graph():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B", table_name="table1")
+    C = MockNode(name="C", table_name="table2")
+    D = MockNode(name="D", table_name="table2")
+    E = MockNode(name="E", table_name="table3")
+    F = MockNode(name="F")
+    G = MockNode(name="G", table_name="table3")
+    graph = {G: [], F: [G], E: [G], D: [F], C: [E, F], A: [C, D], B: [C]}
+    result = custom_topological_sort(graph)
+    assert set(result.keys()) == {A, B, C, D, E, F, G}
+    assert result[C] < result[A] and result[D] < result[A]
+    assert result[C] < result[B]
+    assert result[E] < result[C] and result[F] < result[C]
+    assert result[F] < result[D]
+    assert result[G] < result[E] and result[G] < result[F]
+
+
+def test_cyclic_graph():
+    A = MockNode(name="A")
+    B = MockNode(name="B")
+    C = MockNode(name="C")
+    graph = {A: [B], B: [C], C: [A]}
+    with pytest.raises(ValueError, match="Graph contains a cycle"):
+        custom_topological_sort(graph)
+
+
+def test_empty_graph():
+    graph = {}
+    result = custom_topological_sort(graph)
+    assert result == {}
+
+
+def test_single_node_graph():
+    A = MockNode(name="A")
+    graph = {A: []}
+    result = custom_topological_sort(graph)
+    assert result == {A: 0}
+
+
+def test_all_nodes_same_table():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B", table_name="table1")
+    C = MockNode(name="C", table_name="table1")
+    D = MockNode(name="D", table_name="table1")
+    graph = {D: [], B: [D], C: [D], A: [B, C]}
+    result = custom_topological_sort(graph)
+    assert list(result.keys()) == [D, B, C, A]
+
+
+def test_mixed_node_types():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B")
+    C = MockNode(name="C", table_name="table2")
+    D = MockNode(name="D", table_name="table3")
+    graph = {D: [], C: [D], B: [C], A: [B]}
+    result = custom_topological_sort(graph)
+    assert list(result.keys()) == [D, C, B, A]
+
+
+def test_large_graph_performance():
+    import random
+    import string
+    import time
+
+    def generate_large_graph(size):
+        nodes = [MockNode(name=c) for c in string.ascii_uppercase] + [
+            MockNode(name=f"N{i}") for i in range(size - 26)
+        ]
+        graph = {node: set() for node in nodes}
+        for i, node in enumerate(nodes):
+            graph[node] = set(random.sample(nodes[i + 1 :], min(5, len(nodes) - i - 1)))
+        return graph
+
+    large_graph = generate_large_graph(1000)
+    start_time = time.time()
+    result = custom_topological_sort(large_graph)
+    end_time = time.time()
+    assert len(result) == 1000
+    assert end_time - start_time < 5  # Assuming it should complete within 5 seconds
+
+
+def test_graph_with_isolated_nodes():
+    A = MockNode(name="A")
+    B = MockNode(name="B")
+    C = MockNode(name="C")
+    D = MockNode(name="D")
+    E = MockNode(name="E")
+    graph = {A: [B], B: [], C: [], D: [E], E: []}
+    result = custom_topological_sort(graph)
+    assert set(result.keys()) == {A, B, C, D, E}
+    assert result[B] < result[A]
+    assert result[E] < result[D]
+
+
+# Parameterized test for different graph structures
+@pytest.mark.parametrize(
+    "graph, expected_order",
+    [
+        (
+            {
+                MockNode(name="C"): set(),
+                MockNode(name="B"): {MockNode(name="C")},
+                MockNode(name="A"): {MockNode(name="B")},
+            },
+            ["C", "B", "A"],
+        ),
+        (
+            {
+                MockNode(name="D"): set(),
+                MockNode(name="B"): {MockNode(name="D")},
+                MockNode(name="C"): {MockNode(name="D")},
+                MockNode(name="A"): {MockNode(name="B"), MockNode(name="C")},
+            },
+            ["D", "B", "C", "A"],
+        ),
+    ],
+)
+def test_various_graph_structures(graph, expected_order):
+    result = custom_topological_sort(graph)
+    assert [node.name for node in result.keys()] == expected_order
+
+
+# Test for consistent results with same input
+def test_consistent_results():
+    A = MockNode(name="A", table_name="table1")
+    B = MockNode(name="B", table_name="table1")
+    C = MockNode(name="C", table_name="table2")
+    D = MockNode(name="D", table_name="table2")
+    graph = {D: [], C: [D], B: [D], A: [B, C]}
+    result1 = custom_topological_sort(graph)
+    result2 = custom_topological_sort(graph)
+    assert list(result1.keys()) == list(result2.keys())

--- a/iceaxe/__tests__/migrations/test_action_sorter.py
+++ b/iceaxe/__tests__/migrations/test_action_sorter.py
@@ -42,7 +42,7 @@ def test_simple_dag():
     D = MockNode(name="D")
     graph = {D: [B, C], C: [A], B: [A], A: []}
     result = custom_topological_sort(graph)
-    assert list(result.keys()) == [A, B, C, D]
+    assert list(result.keys()) == [A, C, B, D]
 
 
 def test_disconnected_graph():
@@ -179,7 +179,7 @@ def test_large_graph_performance():
     result = custom_topological_sort(large_graph)
     end_time = time.time()
     assert len(result) == 1000
-    assert end_time - start_time < 5  # Assuming it should complete within 5 seconds
+    assert end_time - start_time < 5
 
 
 def test_graph_with_isolated_nodes():
@@ -195,7 +195,6 @@ def test_graph_with_isolated_nodes():
     assert result[E] < result[D]
 
 
-# Parameterized test for different graph structures
 @pytest.mark.parametrize(
     "graph, expected_order",
     [
@@ -223,8 +222,11 @@ def test_various_graph_structures(graph, expected_order):
     assert [node.name for node in result.keys()] == expected_order
 
 
-# Test for consistent results with same input
 def test_consistent_results():
+    """
+    Test for consistent results with same input
+
+    """
     A = MockNode(name="A", table_name="table1")
     B = MockNode(name="B", table_name="table1")
     C = MockNode(name="C", table_name="table2")

--- a/iceaxe/__tests__/migrations/test_db_memory_serializer.py
+++ b/iceaxe/__tests__/migrations/test_db_memory_serializer.py
@@ -70,8 +70,18 @@ async def test_from_scratch_migration():
     )
 
     assert actions == [
+        DryRunAction(
+            fn=actor.add_type,
+            kwargs={
+                "type_name": "oldvalues",
+                "values": [
+                    "A",
+                ],
+            },
+        ),
         DryRunComment(
             text="\n" "NEW TABLE: modela\n",
+            previous_line=False,
         ),
         DryRunAction(
             fn=actor.add_table,
@@ -92,26 +102,7 @@ async def test_from_scratch_migration():
         DryRunAction(
             fn=actor.add_not_null,
             kwargs={
-                "table_name": "modela",
                 "column_name": "id",
-            },
-        ),
-        DryRunAction(
-            fn=actor.add_type,
-            kwargs={
-                "type_name": "oldvalues",
-                "values": [
-                    "A",
-                ],
-            },
-        ),
-        DryRunAction(
-            fn=actor.add_column,
-            kwargs={
-                "column_name": "was_nullable",
-                "custom_data_type": None,
-                "explicit_data_is_list": False,
-                "explicit_data_type": ColumnType.VARCHAR,
                 "table_name": "modela",
             },
         ),
@@ -128,8 +119,18 @@ async def test_from_scratch_migration():
         DryRunAction(
             fn=actor.add_not_null,
             kwargs={
-                "table_name": "modela",
                 "column_name": "animal",
+                "table_name": "modela",
+            },
+        ),
+        DryRunAction(
+            fn=actor.add_column,
+            kwargs={
+                "column_name": "was_nullable",
+                "custom_data_type": None,
+                "explicit_data_is_list": False,
+                "explicit_data_type": ColumnType.VARCHAR,
+                "table_name": "modela",
             },
         ),
         DryRunAction(
@@ -190,6 +191,16 @@ async def test_diff_migration():
     )
     assert actions == [
         DryRunAction(
+            fn=actor.add_type,
+            kwargs={
+                "type_name": "newvalues",
+                "values": [
+                    "A",
+                    "B",
+                ],
+            },
+        ),
+        DryRunAction(
             fn=actor.add_column,
             kwargs={
                 "column_name": "name",
@@ -202,29 +213,9 @@ async def test_diff_migration():
         DryRunAction(
             fn=actor.add_not_null,
             kwargs={
-                "table_name": "modela",
                 "column_name": "name",
-            },
-        ),
-        DryRunAction(
-            fn=actor.add_type,
-            kwargs={
-                "type_name": "newvalues",
-                "values": [
-                    "A",
-                    "B",
-                ],
-            },
-        ),
-        DryRunAction(
-            fn=actor.add_not_null,
-            kwargs={
-                "column_name": "was_nullable",
                 "table_name": "modela",
             },
-        ),
-        DryRunComment(
-            text=ANY,
         ),
         DryRunAction(
             fn=actor.modify_column_type,
@@ -233,6 +224,17 @@ async def test_diff_migration():
                 "custom_data_type": "newvalues",
                 "explicit_data_is_list": False,
                 "explicit_data_type": None,
+                "table_name": "modela",
+            },
+        ),
+        DryRunComment(
+            text="TODO: Perform a migration of values across types",
+            previous_line=True,
+        ),
+        DryRunAction(
+            fn=actor.add_not_null,
+            kwargs={
+                "column_name": "was_nullable",
                 "table_name": "modela",
             },
         ),
@@ -276,10 +278,26 @@ async def test_duplicate_enum_migration():
     )
 
     assert actions == [
-        DryRunComment(text="\nNEW TABLE: model1\n"),
-        DryRunAction(fn=actor.add_table, kwargs={"table_name": "model1"}),
-        DryRunComment(text="\nNEW TABLE: model2\n"),
-        DryRunAction(fn=actor.add_table, kwargs={"table_name": "model2"}),
+        DryRunAction(
+            fn=actor.add_type,
+            kwargs={
+                "type_name": "enumvalues",
+                "values": [
+                    "A",
+                    "B",
+                ],
+            },
+        ),
+        DryRunComment(
+            text="\n" "NEW TABLE: model1\n",
+            previous_line=False,
+        ),
+        DryRunAction(
+            fn=actor.add_table,
+            kwargs={
+                "table_name": "model1",
+            },
+        ),
         DryRunAction(
             fn=actor.add_column,
             kwargs={
@@ -291,23 +309,11 @@ async def test_duplicate_enum_migration():
             },
         ),
         DryRunAction(
-            fn=actor.add_not_null, kwargs={"column_name": "id", "table_name": "model1"}
-        ),
-        DryRunAction(
-            fn=actor.add_type, kwargs={"type_name": "enumvalues", "values": ["A", "B"]}
-        ),
-        DryRunAction(
-            fn=actor.add_column,
+            fn=actor.add_not_null,
             kwargs={
                 "column_name": "id",
-                "custom_data_type": None,
-                "explicit_data_is_list": False,
-                "explicit_data_type": ColumnType.INTEGER,
-                "table_name": "model2",
+                "table_name": "model1",
             },
-        ),
-        DryRunAction(
-            fn=actor.add_not_null, kwargs={"column_name": "id", "table_name": "model2"}
         ),
         DryRunAction(
             fn=actor.add_column,
@@ -321,36 +327,73 @@ async def test_duplicate_enum_migration():
         ),
         DryRunAction(
             fn=actor.add_not_null,
-            kwargs={"column_name": "value", "table_name": "model1"},
-        ),
-        DryRunAction(
-            fn=actor.add_column,
             kwargs={
                 "column_name": "value",
-                "custom_data_type": "enumvalues",
-                "explicit_data_is_list": False,
-                "explicit_data_type": None,
-                "table_name": "model2",
+                "table_name": "model1",
             },
-        ),
-        DryRunAction(
-            fn=actor.add_not_null,
-            kwargs={"column_name": "value", "table_name": "model2"},
         ),
         DryRunAction(
             fn=actor.add_constraint,
             kwargs={
-                "columns": ["id"],
+                "columns": [
+                    "id",
+                ],
                 "constraint": ConstraintType.PRIMARY_KEY,
                 "constraint_args": None,
                 "constraint_name": "model1_pkey",
                 "table_name": "model1",
             },
         ),
+        DryRunComment(
+            text="\n" "NEW TABLE: model2\n",
+            previous_line=False,
+        ),
+        DryRunAction(
+            fn=actor.add_table,
+            kwargs={
+                "table_name": "model2",
+            },
+        ),
+        DryRunAction(
+            fn=actor.add_column,
+            kwargs={
+                "column_name": "id",
+                "custom_data_type": None,
+                "explicit_data_is_list": False,
+                "explicit_data_type": ColumnType.INTEGER,
+                "table_name": "model2",
+            },
+        ),
+        DryRunAction(
+            fn=actor.add_not_null,
+            kwargs={
+                "column_name": "id",
+                "table_name": "model2",
+            },
+        ),
+        DryRunAction(
+            fn=actor.add_column,
+            kwargs={
+                "column_name": "value",
+                "custom_data_type": "enumvalues",
+                "explicit_data_is_list": False,
+                "explicit_data_type": None,
+                "table_name": "model2",
+            },
+        ),
+        DryRunAction(
+            fn=actor.add_not_null,
+            kwargs={
+                "column_name": "value",
+                "table_name": "model2",
+            },
+        ),
         DryRunAction(
             fn=actor.add_constraint,
             kwargs={
-                "columns": ["id"],
+                "columns": [
+                    "id",
+                ],
                 "constraint": ConstraintType.PRIMARY_KEY,
                 "constraint_args": None,
                 "constraint_name": "model2_pkey",
@@ -536,7 +579,10 @@ def test_enum_column_assignment(clear_all_database_objects):
     migrator = DatabaseMemorySerializer()
     db_objects = list(migrator.delegate([ExampleModel1, ExampleModel2]))
     assert db_objects == [
-        (DBTable(table_name="examplemodel1"), []),
+        (
+            DBTable(table_name="examplemodel1"),
+            [],
+        ),
         (
             DBColumn(
                 table_name="examplemodel1",
@@ -545,16 +591,17 @@ def test_enum_column_assignment(clear_all_database_objects):
                 column_is_list=False,
                 nullable=False,
             ),
-            [DBTable(table_name="examplemodel1")],
+            [
+                DBTable(table_name="examplemodel1"),
+            ],
         ),
         (
             DBType(
                 name="commonenum",
                 values=frozenset({"B", "A"}),
-                # This is the important part where we track the reference columns
                 reference_columns=frozenset({("examplemodel1", "value")}),
             ),
-            [DBTable(table_name="examplemodel1")],
+            [],
         ),
         (
             DBColumn(
@@ -585,7 +632,7 @@ def test_enum_column_assignment(clear_all_database_objects):
             [
                 DBType(
                     name="commonenum",
-                    values=frozenset({"A", "B"}),
+                    values=frozenset({"B", "A"}),
                     reference_columns=frozenset({("examplemodel1", "value")}),
                 ),
                 DBTable(table_name="examplemodel1"),
@@ -605,7 +652,10 @@ def test_enum_column_assignment(clear_all_database_objects):
                 ),
             ],
         ),
-        (DBTable(table_name="examplemodel2"), []),
+        (
+            DBTable(table_name="examplemodel2"),
+            [],
+        ),
         (
             DBColumn(
                 table_name="examplemodel2",
@@ -614,16 +664,17 @@ def test_enum_column_assignment(clear_all_database_objects):
                 column_is_list=False,
                 nullable=False,
             ),
-            [DBTable(table_name="examplemodel2")],
+            [
+                DBTable(table_name="examplemodel2"),
+            ],
         ),
         (
             DBType(
                 name="commonenum",
                 values=frozenset({"B", "A"}),
-                # This is the important part where we track the reference columns
                 reference_columns=frozenset({("examplemodel2", "value")}),
             ),
-            [DBTable(table_name="examplemodel2")],
+            [],
         ),
         (
             DBColumn(
@@ -904,5 +955,5 @@ def test_order_db_objects_sorts_by_table():
         if isinstance(action, (DBTable, DBColumn, DBConstraint))
     ]
 
-    # Table + 3 columns + 1 primary constraint
+    # Table 3 columns 1 primary constraint
     assert table_order == ["modela"] * 5 + ["modelb"] * 5

--- a/iceaxe/migrations/action_sorter.py
+++ b/iceaxe/migrations/action_sorter.py
@@ -1,0 +1,91 @@
+from collections import defaultdict
+
+from iceaxe.migrations.db_stubs import DBObject
+
+
+class ActionTopologicalSorter:
+    """
+    Extends Python's native TopologicalSorter to group nodes by table_name. This provides
+    better semantic grouping within the migrations since most actions are oriented by their
+    parent table.
+
+    - Places cross-table dependencies and non-table actions (like types) according
+        to their default DAG order.
+    - Tables are processed in alphabetical order of their names.
+
+    """
+
+    def __init__(self, graph: dict[DBObject, list[DBObject]]):
+        self.graph = graph
+        self.in_degree = defaultdict(int)
+        self.nodes = set(graph.keys())
+
+        for node, dependencies in graph.items():
+            for dep in dependencies:
+                self.in_degree[node] += 1
+                if dep not in self.nodes:
+                    self.nodes.add(dep)
+                    self.graph[dep] = []
+
+    def sort(self):
+        result = []
+        root_nodes_queued = sorted(
+            [node for node in self.nodes if self.in_degree[node] == 0],
+            key=self.node_key,
+        )
+        if not root_nodes_queued:
+            return result
+
+        # Sort by the table name and then by the node representation
+        root_nodes_queued.sort(key=self.node_key)
+
+        # Always put the non-table actions first (things like global types)
+        non_table_nodes = [
+            node for node in root_nodes_queued if not hasattr(node, "table_name")
+        ]
+        root_nodes_queued = [
+            node for node in root_nodes_queued if node not in non_table_nodes
+        ]
+        root_nodes_queued = non_table_nodes + root_nodes_queued
+
+        queue = [root_nodes_queued.pop(0)]
+        processed = set()
+
+        while True:
+            if not queue:
+                # Pop another root node, if available
+                if root_nodes_queued:
+                    queue.append(root_nodes_queued.pop(0))
+                    continue
+                else:
+                    # If no more root nodes are available and no more work to be done
+                    break
+
+            current_node = queue.pop(0)
+
+            result.append(current_node)
+            processed.add(current_node)
+
+            # Newly unblocked nodes, since we've resolved their dependencies
+            # with the current processing
+            new_ready = []
+            for dependent, deps in self.graph.items():
+                if current_node in deps and dependent not in processed:
+                    self.in_degree[dependent] -= 1
+                    if self.in_degree[dependent] == 0:
+                        new_ready.append(dependent)
+
+            # Add newly ready nodes to queue in sorted order
+            queue.extend(sorted(new_ready, key=self.node_key))
+
+        if len(result) != len(self.nodes):
+            raise ValueError("Graph contains a cycle")
+
+        return result
+
+    @staticmethod
+    def node_key(node: DBObject):
+        # Not all objects specify a table_name, but if they do we want to explicitly
+        # sort before the representation
+        table_name = getattr(node, "table_name", "")
+        return (table_name, node.representation())

--- a/iceaxe/migrations/actions.py
+++ b/iceaxe/migrations/actions.py
@@ -135,6 +135,7 @@ class DryRunAction:
 @dataclass
 class DryRunComment:
     text: str
+    previous_line: bool = False
 
 
 def assert_is_safe_sql_identifier(identifier: str):
@@ -680,6 +681,8 @@ class DatabaseActions:
             self.prod_sqls.append(sql)
             await self.db_connection.conn.execute(sql)
 
-    def add_comment(self, text: str):
+    def add_comment(self, text: str, previous_line: bool = False):
         if self.dry_run:
-            self.dry_run_actions.append(DryRunComment(text=text))
+            self.dry_run_actions.append(
+                DryRunComment(text=text, previous_line=previous_line)
+            )

--- a/iceaxe/migrations/db_stubs.py
+++ b/iceaxe/migrations/db_stubs.py
@@ -153,15 +153,6 @@ class DBColumn(DBColumnBase, DBObject):
             self.column_type != previous.column_type
             or self.column_is_list != previous.column_is_list
         ):
-            previous_column_metadata = " (is list)" if previous.column_is_list else ""
-            new_column_metadata = " (is list)" if self.column_is_list else ""
-
-            actor.add_comment(
-                "Migrating column type from "
-                f"{previous.column_type.name}{previous_column_metadata} to {self.column_type.name}{new_column_metadata}\n"
-                "Changing column type does not perform a migration of values.\n"
-                "Typically you'll want to create a new column, migrate values, and drop the old column instead."
-            )
             await actor.modify_column_type(
                 self.table_name,
                 self.column_name,
@@ -176,6 +167,9 @@ class DBColumn(DBColumnBase, DBObject):
                     if isinstance(self.column_type, DBTypePointer)
                     else None
                 ),
+            )
+            actor.add_comment(
+                "TODO: Perform a migration of values across types", previous_line=True
             )
 
         if not self.nullable and previous.nullable:

--- a/iceaxe/migrations/generator.py
+++ b/iceaxe/migrations/generator.py
@@ -142,10 +142,10 @@ class MigrationGenerator:
                 )
             elif isinstance(action, DryRunComment):
                 if action.previous_line:
+                    # Create a comment that's on the same line
                     previous_line = code_lines.pop()
-                    code_lines.append(
-                        f"{previous_line}  # {action.text.replace('\n', ' ')}"
-                    )
+                    new_comment = action.text.replace("\n", " ")
+                    code_lines.append(f"{previous_line}  # {new_comment}")
                 else:
                     comment_lines = action.text.split("\n")
                     for line in comment_lines:

--- a/iceaxe/migrations/generator.py
+++ b/iceaxe/migrations/generator.py
@@ -141,9 +141,15 @@ class MigrationGenerator:
                     f"await migrator.actor.{migrator_signature}({kwargs})"
                 )
             elif isinstance(action, DryRunComment):
-                comment_lines = action.text.split("\n")
-                for line in comment_lines:
-                    code_lines.append(f"# {line}")
+                if action.previous_line:
+                    previous_line = code_lines.pop()
+                    code_lines.append(
+                        f"{previous_line}  # {action.text.replace('\n', ' ')}"
+                    )
+                else:
+                    comment_lines = action.text.split("\n")
+                    for line in comment_lines:
+                        code_lines.append(f"# {line}")
             else:
                 raise ValueError(f"Unknown action type: {action}")
 


### PR DESCRIPTION
Our previous migration sorting strategy relied on a standard topological sort to make sure our database dependencies are satisfied before creating downstream objects (tables > columns, columns > constraints, etc.) This often resulted in a visually jumbled order of the migrations, however, as we would position all the new tables up front followed by various columns belonging to those tables because they all have the same in-node count.

This PR introduces a more suitable topological sort algorithm, which groups operations by their tables and processes dependencies in a DFS instead of the normal sorter's BFS.