### PR TITLE
Support deletion and generic tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you're using poetry to manage your dependencies:
 poetry add iceaxe
 ```
 
-Otherwise install with pip
+Otherwise install with pip:
 
 ```bash
 pip install iceaxe

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -9,7 +9,7 @@ from iceaxe.session import (
 from iceaxe.typing import column
 
 #
-# Insert / Update with ORM objects
+# Insert / Update / Delete with ORM objects
 #
 
 
@@ -126,6 +126,24 @@ async def test_db_connection_update_no_modifications(db_connection: DBConnection
     assert len(result) == 1
     assert result[0]["name"] == "John Doe"
     assert result[0]["email"] == "john@example.com"
+
+
+@pytest.mark.asyncio
+async def test_delete_object(db_connection: DBConnection):
+    user = UserDemo(name="John Doe", email="john@example.com")
+    await db_connection.insert([user])
+
+    result = await db_connection.conn.fetch(
+        "SELECT * FROM userdemo WHERE id = $1", user.id
+    )
+    assert len(result) == 1
+
+    await db_connection.delete([user])
+
+    result = await db_connection.conn.fetch(
+        "SELECT * FROM userdemo WHERE id = $1", user.id
+    )
+    assert len(result) == 0
 
 
 #

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from inspect import isgenerator
-from typing import Any, Generator, Sequence, Type
+from typing import Any, Generator, Sequence, Type, TypeVar
 from uuid import UUID
 
 from pydantic_core import PydanticUndefined
@@ -14,6 +14,7 @@ from iceaxe.base import (
     UniqueConstraint,
 )
 from iceaxe.generics import (
+    get_typevar_mapping,
     has_null_type,
     is_type_compatible,
     remove_null_type,
@@ -311,6 +312,11 @@ class DatabaseHandler:
             raise ValueError(f"Annotation must be provided for {table.__name__}.{key}")
 
         annotation = remove_null_type(info.annotation)
+
+        # Resolve the type of the column, if generic
+        if isinstance(annotation, TypeVar):
+            typevar_map = get_typevar_mapping(table)
+            annotation = typevar_map[annotation]
 
         # Should be prioritized in terms of MRO; StrEnums should be processed
         # before the str types


### PR DESCRIPTION
Support deletion of ORM objects. Also refactor the implementation of update() to cache table-specific helper variables once per model type that's passed.

We also fix a bug within our in-memory table serializer for generic table definitions. This fixes the error for:

>  Unsupported column type: ~T