### PR TITLE
Support subclasses of generic models

### DIFF
--- a/iceaxe/__tests__/conftest.py
+++ b/iceaxe/__tests__/conftest.py
@@ -1,6 +1,8 @@
 import asyncpg
+import pytest
 import pytest_asyncio
 
+from iceaxe.base import DBModelMetaclass
 from iceaxe.session import DBConnection
 
 
@@ -88,3 +90,14 @@ async def clear_all_database_objects(db_connection: DBConnection):
         END $$;
     """
     )
+
+
+@pytest.fixture
+def clear_registry():
+    current_registry = DBModelMetaclass._registry
+    DBModelMetaclass._registry = []
+
+    try:
+        yield
+    finally:
+        DBModelMetaclass._registry = current_registry

--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 import pytest
 
@@ -178,3 +178,15 @@ def test_not_autodetect():
         pass
 
     assert WillNotAutodetect not in DBModelMetaclass.get_registry()
+
+
+def test_not_autodetect_generic(clear_registry):
+    T = TypeVar("T")
+
+    class GenericSuperclass(TableBase, Generic[T], autodetect=False):
+        value: T
+
+    class WillAutodetect(GenericSuperclass[int]):
+        pass
+
+    assert DBModelMetaclass.get_registry() == [WillAutodetect]


### PR DESCRIPTION
When generic superclasses are used in pydantic, pydantic instantiates a concrete class via `__class_getitem__` https://github.com/pydantic/pydantic/blob/main/pydantic/main.py#L743. This concrete creator doesn't pass down the class kwargs. We solve this at the metaclass level by inspecting the MRO for fallback values.