### PR TITLE
Use identity operator for null comparisons

### DIFF
--- a/iceaxe/__tests__/test_comparison.py
+++ b/iceaxe/__tests__/test_comparison.py
@@ -17,6 +17,8 @@ def test_comparison_type_enum():
     assert ComparisonType.IN == "IN"
     assert ComparisonType.NOT_IN == "NOT IN"
     assert ComparisonType.LIKE == "LIKE"
+    assert ComparisonType.IS == "IS"
+    assert ComparisonType.IS_NOT == "IS NOT"
 
 
 @pytest.fixture
@@ -34,12 +36,28 @@ def test_eq(db_field: DBFieldClassDefinition):
     assert result.right == 5
 
 
+def test_eq_none(db_field: DBFieldClassDefinition):
+    result = db_field == None  # noqa: E711
+    assert isinstance(result, FieldComparison)
+    assert result.left == db_field
+    assert result.comparison == ComparisonType.IS
+    assert result.right is None
+
+
 def test_ne(db_field: DBFieldClassDefinition):
     result = db_field != 5
     assert isinstance(result, FieldComparison)
     assert result.left == db_field
     assert result.comparison == ComparisonType.NE
     assert result.right == 5
+
+
+def test_ne_none(db_field: DBFieldClassDefinition):
+    result = db_field != None  # noqa: E711
+    assert isinstance(result, FieldComparison)
+    assert result.left == db_field
+    assert result.comparison == ComparisonType.IS_NOT
+    assert result.right is None
 
 
 def test_lt(db_field: DBFieldClassDefinition):

--- a/iceaxe/comparison.py
+++ b/iceaxe/comparison.py
@@ -19,6 +19,8 @@ class ComparisonType(StrEnum):
     IN = "IN"
     NOT_IN = "NOT IN"
     LIKE = "LIKE"
+    IS = "IS"
+    IS_NOT = "IS NOT"
 
 
 class ComparisonGroupType(StrEnum):
@@ -80,9 +82,13 @@ class FieldComparisonGroup:
 
 class ComparisonBase(ABC):
     def __eq__(self, other):  # type: ignore
+        if other is None:
+            return self._compare(ComparisonType.IS, None)
         return self._compare(ComparisonType.EQ, other)
 
     def __ne__(self, other):  # type: ignore
+        if other is None:
+            return self._compare(ComparisonType.IS_NOT, None)
         return self._compare(ComparisonType.NE, other)
 
     def __lt__(self, other):


### PR DESCRIPTION
`None` values should be compared in SQL with `IS` and `IS NOT` versus our existing value equality operators. This requires `noqa: E711` exclusions in Python, but is otherwise the most natural way to model this comparison.