### PR TITLE
Construct bulk delete query

### DIFF
--- a/iceaxe/__init__.py
+++ b/iceaxe/__init__.py
@@ -9,6 +9,7 @@ from .postgres import PostgresDateTime as PostgresDateTime, PostgresTime as Post
 from .queries import (
     QueryBuilder as QueryBuilder,
     and_ as and_,
+    delete as delete,
     or_ as or_,
     select as select,
     update as update,

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -139,6 +139,14 @@ def test_update():
     )
 
 
+def test_delete():
+    new_query = QueryBuilder().delete(UserDemo).where(UserDemo.id == 1)
+    assert new_query.build() == (
+        'DELETE FROM "userdemo" WHERE "userdemo"."id" = $1',
+        [1],
+    )
+
+
 def test_text():
     new_query = QueryBuilder().text("SELECT * FROM users WHERE id = $1", 1)
     assert new_query.build() == ("SELECT * FROM users WHERE id = $1", [1])


### PR DESCRIPTION
Expand deletion support to custom constructed queries, versus our existing deletion where you need to have an ORM object already in memory.