### PR TITLE
Add upsert support

### DIFF
--- a/iceaxe/__tests__/conf_models.py
+++ b/iceaxe/__tests__/conf_models.py
@@ -1,5 +1,7 @@
 from contextlib import contextmanager
+from enum import StrEnum
 from pathlib import Path
+from typing import Any
 
 from pyinstrument import Profiler
 
@@ -22,6 +24,44 @@ class ComplexDemo(TableBase):
     id: int = Field(primary_key=True, default=None)
     string_list: list[str]
     json_data: dict[str, str] = Field(is_json=True)
+
+
+class Employee(TableBase):
+    id: int = Field(primary_key=True, default=None)
+    email: str = Field(unique=True)
+    first_name: str
+    last_name: str
+    department: str
+    salary: float
+
+
+class Department(TableBase):
+    id: int = Field(primary_key=True, default=None)
+    name: str = Field(unique=True)
+    budget: float
+    location: str
+
+
+class ProjectAssignment(TableBase):
+    id: int = Field(primary_key=True, default=None)
+    employee_id: int = Field(foreign_key="employee.id")
+    project_name: str
+    role: str
+    start_date: str
+
+
+class EmployeeStatus(StrEnum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    ON_LEAVE = "on_leave"
+
+
+class EmployeeMetadata(TableBase):
+    id: int = Field(primary_key=True, default=None)
+    employee_id: int = Field(foreign_key="employee.id")
+    status: EmployeeStatus
+    tags: list[str] = Field(is_json=True)
+    additional_info: dict[str, Any] = Field(is_json=True)
 
 
 @contextmanager

--- a/iceaxe/__tests__/test_comparison.py
+++ b/iceaxe/__tests__/test_comparison.py
@@ -4,7 +4,7 @@ import pytest
 
 from iceaxe.base import TableBase
 from iceaxe.comparison import ComparisonType, FieldComparison
-from iceaxe.field import DBFieldClassDefinition, FieldInfo
+from iceaxe.field import DBFieldClassDefinition, DBFieldInfo
 
 
 def test_comparison_type_enum():
@@ -24,7 +24,7 @@ def test_comparison_type_enum():
 @pytest.fixture
 def db_field():
     return DBFieldClassDefinition(
-        root_model=TableBase, key="test_key", field_definition=FieldInfo()
+        root_model=TableBase, key="test_key", field_definition=DBFieldInfo()
     )
 
 
@@ -137,7 +137,7 @@ def test_compare(db_field: DBFieldClassDefinition):
         3.14,
         complex(1, 2),
         DBFieldClassDefinition(
-            root_model=TableBase, key="other_key", field_definition=FieldInfo()
+            root_model=TableBase, key="other_key", field_definition=DBFieldInfo()
         ),
     ],
 )

--- a/iceaxe/__tests__/test_field.py
+++ b/iceaxe/__tests__/test_field.py
@@ -4,13 +4,13 @@ import pytest
 
 from iceaxe.base import TableBase
 from iceaxe.comparison import ComparisonType, FieldComparison
-from iceaxe.field import DBFieldClassDefinition, FieldInfo
+from iceaxe.field import DBFieldClassDefinition, DBFieldInfo
 
 
 @pytest.fixture
 def db_field():
     return DBFieldClassDefinition(
-        root_model=TableBase, key="test_key", field_definition=FieldInfo()
+        root_model=TableBase, key="test_key", field_definition=DBFieldInfo()
     )
 
 
@@ -107,7 +107,7 @@ def test_compare(db_field: DBFieldClassDefinition):
         3.14,
         complex(1, 2),
         DBFieldClassDefinition(
-            root_model=TableBase, key="other_key", field_definition=FieldInfo()
+            root_model=TableBase, key="other_key", field_definition=DBFieldInfo()
         ),
     ],
 )
@@ -132,8 +132,8 @@ def test_comparison_with_different_types(db_field: DBFieldClassDefinition, value
 
 def test_db_field_class_definition_instantiation():
     field_def = DBFieldClassDefinition(
-        root_model=TableBase, key="test_key", field_definition=FieldInfo()
+        root_model=TableBase, key="test_key", field_definition=DBFieldInfo()
     )
     assert field_def.root_model == TableBase
     assert field_def.key == "test_key"
-    assert isinstance(field_def.field_definition, FieldInfo)
+    assert isinstance(field_def.field_definition, DBFieldInfo)

--- a/iceaxe/field.py
+++ b/iceaxe/field.py
@@ -1,3 +1,4 @@
+from json import dumps as json_dumps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -92,6 +93,11 @@ class DBFieldInfo(FieldInfo):
             **field._attributes_set,  # type: ignore
         )
 
+    def to_db_value(self, value: Any):
+        if self.is_json:
+            return json_dumps(value)
+        return value
+
 
 def __get_db_field(_: Callable[Concatenate[Any, P], Any] = PydanticField):  # type: ignore
     """
@@ -136,13 +142,13 @@ def __get_db_field(_: Callable[Concatenate[Any, P], Any] = PydanticField):  # ty
 class DBFieldClassDefinition(ComparisonBase):
     root_model: Type["TableBase"]
     key: str
-    field_definition: FieldInfo
+    field_definition: DBFieldInfo
 
     def __init__(
         self,
         root_model: Type["TableBase"],
         key: str,
-        field_definition: FieldInfo,
+        field_definition: DBFieldInfo,
     ):
         self.root_model = root_model
         self.key = key


### PR DESCRIPTION
In Postgres, an upsert is just a special case of INSERT with the extended `ON CONFLICT` flags. While we could override our connection.insert method to support this case, it overly complicates the API contract for a case that is pretty disjoint in practical usage. This PR adds new explicit logic to insert a batch of objects and optionally return fields:

```python
    await db_connection.conn.execute(
        """
        ALTER TABLE userdemo
        ADD CONSTRAINT email_unique UNIQUE (name, email)
        """
    )

    users = [
        UserDemo(name="John Doe", email="john@example.com"),
        UserDemo(name="John Doe", email="john@example.com"),
        UserDemo(name="Jane Doe", email="jane@example.com"),
    ]
    result = await db_connection.upsert(
        users,
        conflict_fields=(UserDemo.name, UserDemo.email),
        returning_fields=(UserDemo.name, UserDemo.email),
    )

    assert result is not None
    assert len(result) == 2
    assert {r[1] for r in result} == {"john@example.com", "jane@example.com"}
```