### PR TITLE
Add support for returning multiple joined tables

### DIFF
--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -9,7 +9,11 @@ from iceaxe.queries import QueryBuilder, and_, or_, select
 
 def test_select():
     new_query = QueryBuilder().select(UserDemo)
-    assert new_query.build() == ('SELECT "userdemo".* FROM "userdemo"', [])
+    assert new_query.build() == (
+        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
+        '"userdemo_name", "userdemo"."email" as "userdemo_email" FROM "userdemo"',
+        [],
+    )
 
 
 def test_select_single_field():

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -282,7 +282,7 @@ async def test_select_join(db_connection: DBConnection):
 
 
 @pytest.mark.asyncio
-async def test_select_join_objects(db_connection: DBConnection):
+async def test_select_join_multiple_tables(db_connection: DBConnection):
     user = UserDemo(name="John Doe", email="john@example.com")
     await db_connection.insert([user])
     assert user.id is not None

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -282,6 +282,30 @@ async def test_select_join(db_connection: DBConnection):
 
 
 @pytest.mark.asyncio
+async def test_select_join_objects(db_connection: DBConnection):
+    user = UserDemo(name="John Doe", email="john@example.com")
+    await db_connection.insert([user])
+    assert user.id is not None
+
+    artifact = ArtifactDemo(title="Artifact 1", user_id=user.id)
+    await db_connection.insert([artifact])
+
+    new_query = (
+        QueryBuilder()
+        .select((ArtifactDemo, UserDemo))
+        .join(UserDemo, UserDemo.id == ArtifactDemo.user_id)
+        .where(UserDemo.name == "John Doe")
+    )
+    result = await db_connection.exec(new_query)
+    assert result == [
+        (
+            ArtifactDemo(id=artifact.id, title="Artifact 1", user_id=user.id),
+            UserDemo(id=user.id, name="John Doe", email="john@example.com"),
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_select_with_limit_and_offset(db_connection: DBConnection):
     users = [
         UserDemo(name="User 1", email="user1@example.com"),

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -136,3 +136,11 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         if cls.table_name == PydanticUndefined:
             return cls.__name__.lower()
         return cls.table_name
+
+    @classmethod
+    def get_client_fields(cls):
+        return {
+            field: info
+            for field, info in cls.model_fields.items()
+            if field not in INTERNAL_TABLE_FIELDS
+        }

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -137,6 +137,11 @@ class QueryBuilder(Generic[P, QueryType]):
         Creates a new select query for the given fields. Returns the same
         QueryBuilder that is now flagged as a SELECT query.
 
+        Our select @overrides here support the required conversion from a table class (which
+        is specified as raw input) to individual instances which are returned. This is only
+        relevant for table classes since field selections should be 1:1 mirrored from the
+        request field annotation to the response type.
+
         """
         all_fields: tuple[
             DBFieldClassDefinition | Type[TableBase] | FunctionMetadata, ...

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -29,17 +29,20 @@ from iceaxe.typing import (
 
 P = TypeVar("P")
 
-T = TypeVar(
-    "T",
-    bound=TableBase
+SUPPORTED_SELECTS = (
+    TableBase
     | DBModelMetaclass
     | ALL_ENUM_TYPES
     | PRIMITIVE_TYPES
     | PRIMITIVE_WRAPPER_TYPES
     | DATE_TYPES
     | JSON_WRAPPER_FALLBACK
-    | None,
+    | None
 )
+
+T = TypeVar("T", bound=SUPPORTED_SELECTS)
+T2 = TypeVar("T2", bound=SUPPORTED_SELECTS)
+T3 = TypeVar("T3", bound=SUPPORTED_SELECTS)
 Ts = TypeVarTuple("Ts")
 
 
@@ -102,14 +105,33 @@ class QueryBuilder(Generic[P, QueryType]):
 
     @overload
     def select(
-        self, fields: tuple[T | Type[T], *Ts]
-    ) -> QueryBuilder[tuple[T, *Ts], Literal["SELECT"]]: ...
+        self, fields: tuple[T | Type[T]]
+    ) -> QueryBuilder[tuple[T], Literal["SELECT"]]: ...
+
+    @overload
+    def select(
+        self, fields: tuple[T | Type[T], T2 | Type[T2]]
+    ) -> QueryBuilder[tuple[T, T2], Literal["SELECT"]]: ...
+
+    @overload
+    def select(
+        self, fields: tuple[T | Type[T], T2 | Type[T2], T3 | Type[T3], *Ts]
+    ) -> QueryBuilder[tuple[T, T2, T3, *Ts], Literal["SELECT"]]: ...
 
     def select(
-        self, fields: T | Type[T] | tuple[T | Type[T], *Ts]
+        self,
+        fields: (
+            T
+            | Type[T]
+            | tuple[T | Type[T]]
+            | tuple[T | Type[T], T2 | Type[T2]]
+            | tuple[T | Type[T], T2 | Type[T2], T3 | Type[T3], *Ts]
+        ),
     ) -> (
-        QueryBuilder[tuple[T, *Ts], Literal["SELECT"]]
-        | QueryBuilder[T, Literal["SELECT"]]
+        QueryBuilder[T, Literal["SELECT"]]
+        | QueryBuilder[tuple[T], Literal["SELECT"]]
+        | QueryBuilder[tuple[T, T2], Literal["SELECT"]]
+        | QueryBuilder[tuple[T, T2, T3, *Ts], Literal["SELECT"]]
     ):
         """
         Creates a new select query for the given fields. Returns the same
@@ -467,14 +489,35 @@ def select(fields: T | Type[T]) -> QueryBuilder[T, Literal["SELECT"]]: ...
 
 @overload
 def select(
-    fields: tuple[T | Type[T], *Ts],
-) -> QueryBuilder[tuple[T, *Ts], Literal["SELECT"]]: ...
+    fields: tuple[T | Type[T]],
+) -> QueryBuilder[tuple[T], Literal["SELECT"]]: ...
+
+
+@overload
+def select(
+    fields: tuple[T | Type[T], T2 | Type[T2]],
+) -> QueryBuilder[tuple[T, T2], Literal["SELECT"]]: ...
+
+
+@overload
+def select(
+    fields: tuple[T | Type[T], T2 | Type[T2], T3 | Type[T3], *Ts],
+) -> QueryBuilder[tuple[T, T2, T3, *Ts], Literal["SELECT"]]: ...
 
 
 def select(
-    fields: T | Type[T] | tuple[T | Type[T], *Ts],
+    fields: (
+        T
+        | Type[T]
+        | tuple[T | Type[T]]
+        | tuple[T | Type[T], T2 | Type[T2]]
+        | tuple[T | Type[T], T2 | Type[T2], T3 | Type[T3], *Ts]
+    ),
 ) -> (
-    QueryBuilder[tuple[T, *Ts], Literal["SELECT"]] | QueryBuilder[T, Literal["SELECT"]]
+    QueryBuilder[T, Literal["SELECT"]]
+    | QueryBuilder[tuple[T], Literal["SELECT"]]
+    | QueryBuilder[tuple[T, T2], Literal["SELECT"]]
+    | QueryBuilder[tuple[T, T2, T3, *Ts], Literal["SELECT"]]
 ):
     """
     Shortcut to create a SELECT query with a new QueryBuilder.

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -165,8 +165,15 @@ class QueryBuilder(Generic[P, QueryType]):
                 self.select_raw.append(field)
             elif is_base_table(field):
                 table_token = QueryIdentifier(field.get_table_name())
-                field_token = QueryLiteral("*")
-                self.select_fields.append(QueryLiteral(f"{table_token}.{field_token}"))
+
+                for field_name in field.get_client_fields():
+                    field_token = QueryIdentifier(field_name)
+                    return_field = QueryIdentifier(
+                        f"{field.get_table_name()}_{field_name}"
+                    )
+                    self.select_fields.append(
+                        QueryLiteral(f"{table_token}.{field_token} as {return_field}")
+                    )
                 self.select_raw.append(field)
             elif is_function_metadata(field):
                 field.local_name = f"aggregate_{self.select_aggregate_count}"

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -7,7 +7,6 @@ from uuid import UUID
 from pydantic_core import PydanticUndefined
 
 from iceaxe.base import (
-    INTERNAL_TABLE_FIELDS,
     DBFieldInfo,
     IndexConstraint,
     TableBase,
@@ -244,11 +243,7 @@ class DatabaseHandler:
 
         # Handle the columns
         all_column_nodes: list[NodeDefinition] = []
-        for field_name, field in table.model_fields.items():
-            # Only create user-columns
-            if field_name in INTERNAL_TABLE_FIELDS:
-                continue
-
+        for field_name, field in table.get_client_fields().items():
             column_nodes = self._yield_nodes(
                 self.convert_column(field_name, field, table), dependencies=table_nodes
             )

--- a/iceaxe/session_optimized.pyx
+++ b/iceaxe/session_optimized.pyx
@@ -1,102 +1,188 @@
-# cython_optimizations.pyx
-from typing import Any, List, Tuple, Type
+from typing import Any, List, Tuple
 from iceaxe.base import TableBase
 from iceaxe.queries import FunctionMetadata
 from json import loads as json_loads
 from cpython.ref cimport PyObject
 from cpython.object cimport PyObject_GetItem
 from libc.stdlib cimport malloc, free
-from libc.string cimport strcpy
+from libc.string cimport memcpy
+from cpython.ref cimport Py_INCREF, Py_DECREF
 
 cdef struct FieldInfo:
-    char* name
-    bint is_json
+    char* name                # Field name
+    char* select_attribute    # Corresponding attribute in the select_raw
+    bint is_json              # Flag indicating if the field is JSON
 
-cdef list optimize_casting(list values, list select_raws, list select_types):
-    cdef:
-        Py_ssize_t i, j, k, num_values, num_selects
-        list result_all
-        PyObject **result_value
-        object value, obj, item
-        tuple select_type
-        bint raw_is_table, raw_is_column, raw_is_function_metadata
-        FieldInfo **fields
-        Py_ssize_t num_fields
-        dict field_dict
-        bytes field_bytes
-        char* c_field_name
+cdef char* allocate_cstring(bytes data):
+    cdef Py_ssize_t length = len(data)
+    cdef char* c_str = <char*>malloc((length + 1) * sizeof(char))
+    if not c_str:
+        raise MemoryError("Failed to allocate memory for C string.")
+    memcpy(c_str, <char*>data, length)  # Cast bytes to char* for memcpy
+    c_str[length] = 0  # Null-terminate the string
+    return c_str
 
-    num_values = len(values)
-    num_selects = len(select_raws)
-    result_all = [None] * num_values
-
-    # Pre-calculate field information
-    fields = <FieldInfo**>malloc(num_selects * sizeof(FieldInfo*))
-    if not fields:
-        raise MemoryError()
-
-    try:
+cdef void free_fields(FieldInfo** fields, Py_ssize_t* num_fields_array, Py_ssize_t num_selects):
+    cdef Py_ssize_t j, k
+    if fields:
         for j in range(num_selects):
-            select_raw = select_raws[j]
-            raw_is_table, raw_is_column, raw_is_function_metadata = select_types[j]
-            if raw_is_table:
-                field_dict = {}
-                for field, info in select_raw.model_fields.items():
-                    if not info.exclude:
-                        field_dict[field] = info.is_json
-                num_fields = len(field_dict)
-                fields[j] = <FieldInfo*>malloc(num_fields * sizeof(FieldInfo))
-                if not fields[j]:
-                    raise MemoryError()
-                for k, (field, is_json) in enumerate(field_dict.items()):
-                    field_bytes = field.encode('utf-8')
-                    c_field_name = <char*>malloc((len(field_bytes) + 1) * sizeof(char))
-                    if not c_field_name:
-                        raise MemoryError()
-                    strcpy(c_field_name, field_bytes)
-                    fields[j][k].name = c_field_name
-                    fields[j][k].is_json = is_json
-
-        for i in range(num_values):
-            value = values[i]
-            result_value = <PyObject**>malloc(num_selects * sizeof(PyObject*))
-            if not result_value:
-                raise MemoryError()
-            try:
-                for j in range(num_selects):
-                    select_raw = select_raws[j]
-                    raw_is_table, raw_is_column, raw_is_function_metadata = select_types[j]
-                    if raw_is_table:
-                        obj_dict = {}
-                        for k in range(num_fields):
-                            field_name = fields[j][k].name.decode('utf-8')
-                            field_value = PyObject_GetItem(value, field_name)
-                            if fields[j][k].is_json:
-                                field_value = json_loads(field_value)
-                            obj_dict[field_name] = field_value
-                        obj = select_raw(**obj_dict)
-                        result_value[j] = <PyObject*>obj
-                    elif raw_is_column:
-                        item = PyObject_GetItem(value, select_raw.key)
-                        result_value[j] = <PyObject*>item
-                    elif raw_is_function_metadata:
-                        item = PyObject_GetItem(value, select_raw.local_name)
-                        result_value[j] = <PyObject*>item
-                if num_selects == 1:
-                    result_all[i] = <object>result_value[0]
-                else:
-                    result_all[i] = tuple([<object>result_value[j] for j in range(num_selects)])
-            finally:
-                free(result_value)
-    finally:
-        for j in range(num_selects):
-            if select_types[j][0]:  # if raw_is_table
-                for k in range(num_fields):
+            if fields[j]:
+                for k in range(num_fields_array[j]):
                     free(fields[j][k].name)
+                    free(fields[j][k].select_attribute)
                 free(fields[j])
         free(fields)
+    if num_fields_array:
+        free(num_fields_array)
+
+cdef FieldInfo** precompute_fields(list select_raws, list select_types, Py_ssize_t num_selects, Py_ssize_t* num_fields_array):
+    cdef FieldInfo** fields = <FieldInfo**>malloc(num_selects * sizeof(FieldInfo*))
+    cdef Py_ssize_t j, k, num_fields
+    cdef dict field_dict
+    cdef bytes select_bytes, field_bytes
+    cdef char* c_select
+    cdef char* c_field
+    cdef object select_raw
+    cdef bint raw_is_table, raw_is_column, raw_is_function_metadata
+
+    if not fields:
+        raise MemoryError("Failed to allocate memory for fields.")
+
+    for j in range(num_selects):
+        select_raw = select_raws[j]
+        raw_is_table, raw_is_column, raw_is_function_metadata = select_types[j]
+
+        if raw_is_table:
+            field_dict = {field: info.is_json for field, info in select_raw.get_client_fields().items() if not info.exclude}
+            num_fields = len(field_dict)
+            num_fields_array[j] = num_fields
+            fields[j] = <FieldInfo*>malloc(num_fields * sizeof(FieldInfo))
+            if not fields[j]:
+                raise MemoryError("Failed to allocate memory for FieldInfo.")
+
+            for k, (field, is_json) in enumerate(field_dict.items()):
+                select_bytes = f"{select_raw.get_table_name()}_{field}".encode('utf-8')
+                c_select = allocate_cstring(select_bytes)
+
+                field_bytes = field.encode('utf-8')
+                c_field = allocate_cstring(field_bytes)
+
+                fields[j][k].select_attribute = c_select
+                fields[j][k].name = c_field
+                fields[j][k].is_json = is_json
+        else:
+            num_fields_array[j] = 0
+            fields[j] = NULL
+
+    return fields
+
+cdef list process_values(
+    list values,
+    FieldInfo** fields,
+    Py_ssize_t* num_fields_array,
+    list select_raws,
+    list select_types,
+    Py_ssize_t num_selects
+):
+    cdef Py_ssize_t num_values = len(values)
+    cdef list result_all = [None] * num_values
+    cdef Py_ssize_t i, j, k, num_fields
+    cdef PyObject** result_value
+    cdef object value, obj, item
+    cdef dict obj_dict
+    cdef bint raw_is_table, raw_is_column, raw_is_function_metadata
+    cdef char* field_name_c
+    cdef char* select_name_c
+    cdef str field_name
+    cdef str select_name
+    cdef object field_value
+    cdef object select_raw
+    cdef PyObject* temp_obj
+
+    for i in range(num_values):
+        value = values[i]
+        result_value = <PyObject**>malloc(num_selects * sizeof(PyObject*))
+        if not result_value:
+            raise MemoryError("Failed to allocate memory for result_value.")
+        try:
+            for j in range(num_selects):
+                select_raw = select_raws[j]
+                raw_is_table, raw_is_column, raw_is_function_metadata = select_types[j]
+
+                if raw_is_table:
+                    obj_dict = {}
+                    num_fields = num_fields_array[j]
+                    for k in range(num_fields):
+                        field_name_c = fields[j][k].name
+                        select_name_c = fields[j][k].select_attribute
+                        field_name = field_name_c.decode('utf-8')
+                        select_name = select_name_c.decode('utf-8')
+
+                        try:
+                            field_value = value[select_name]  # Use Python dictionary access instead of PyObject_GetItem
+                        except KeyError:
+                            raise KeyError(f"Key '{select_name}' not found in value.")
+
+                        if fields[j][k].is_json:
+                            field_value = json_loads(field_value)
+
+                        obj_dict[field_name] = field_value
+
+                    obj = select_raw(**obj_dict)
+                    result_value[j] = <PyObject*>obj
+                    Py_INCREF(obj)  # Increment reference count for the stored object
+
+                elif raw_is_column:
+                    try:
+                        item = value[select_raw.key]  # Use Python dictionary access
+                    except KeyError:
+                        raise KeyError(f"Key '{select_raw.key}' not found in value.")
+                    result_value[j] = <PyObject*>item
+                    Py_INCREF(item)
+
+                elif raw_is_function_metadata:
+                    try:
+                        item = value[select_raw.local_name]  # Use Python dictionary access
+                    except KeyError:
+                        raise KeyError(f"Key '{select_raw.local_name}' not found in value.")
+                    result_value[j] = <PyObject*>item
+                    Py_INCREF(item)
+
+            # Assemble the result
+            if num_selects == 1:
+                result_all[i] = <object>result_value[0]
+                Py_DECREF(<object>result_value[0])  # Decrement reference count
+            else:
+                result_tuple = tuple([<object>result_value[j] for j in range(num_selects)])
+                for j in range(num_selects):
+                    Py_DECREF(<object>result_value[j])  # Decrement reference count for each item
+                result_all[i] = result_tuple
+
+        finally:
+            free(result_value)
 
     return result_all
 
-def optimize_exec_casting(values: List[Any], select_raw: List[Any], select_types: List[Tuple[bool, bool, bool]]) -> List[Any]:
-    return optimize_casting(values, select_raw, select_types)
+cdef list optimize_casting(list values, list select_raws, list select_types):
+    cdef Py_ssize_t num_selects = len(select_raws)
+    cdef Py_ssize_t* num_fields_array = <Py_ssize_t*>malloc(num_selects * sizeof(Py_ssize_t))
+    cdef FieldInfo** fields
+    cdef list result_all
+
+    if not num_fields_array:
+        raise MemoryError("Failed to allocate memory for num_fields_array.")
+
+    try:
+        fields = precompute_fields(select_raws, select_types, num_selects, num_fields_array)
+        result_all = process_values(values, fields, num_fields_array, select_raws, select_types, num_selects)
+    finally:
+        free_fields(fields, num_fields_array, num_selects)
+
+    return result_all
+
+def optimize_exec_casting(
+    values: List[Any],
+    select_raws: List[Any],
+    select_types: List[Tuple[bool, bool, bool]]
+) -> List[Any]:
+    return optimize_casting(values, select_raws, select_types)


### PR DESCRIPTION
Our previous table query generation relied on the start operator to retrieve all table fields. This worked for one return table (or for multiple tables with completely disjoint values) but failed as soon as values overlapped, as SQL would only return the last one in the ordering chain. We refactor our table selection to use a coupled `table_column` response to avoid this conflict and further update our casting pipeline to leverage it.