### PR TITLE
Allow null instances during object casting

### DIFF
--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -442,6 +442,32 @@ async def test_select_with_left_join(db_connection: DBConnection):
     assert result[1] == ("John", 2)
 
 
+@pytest.mark.asyncio
+async def test_select_with_left_join_object(db_connection: DBConnection):
+    users = [
+        UserDemo(name="John", email="john@example.com"),
+        UserDemo(name="Jane", email="jane@example.com"),
+    ]
+    await db_connection.insert(users)
+
+    posts = [
+        ArtifactDemo(title="John's Post", user_id=users[0].id),
+        ArtifactDemo(title="Another Post", user_id=users[0].id),
+    ]
+    await db_connection.insert(posts)
+
+    query = (
+        QueryBuilder()
+        .select((UserDemo, ArtifactDemo))
+        .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, "LEFT")
+    )
+    result = await db_connection.exec(query)
+    assert len(result) == 3
+    assert result[0] == (users[0], posts[0])
+    assert result[1] == (users[0], posts[1])
+    assert result[2] == (users[1], None)
+
+
 # @pytest.mark.asyncio
 # async def test_select_with_subquery(db_connection: DBConnection):
 #     users = [


### PR DESCRIPTION
For any join type other than INNER, it's possible that the other table will not be found and nones will be returned for all of the selected identifiers. This is difficult to properly typehint since the `.join` needs to modify the dynamic return values of the `select`, so for the time being we don't adjust the `select` typehints if they're included. Instead we just appropriately handle the parsing of missing records into a full None in the Cython pipeline.