### PR TITLE
Allow users to manually format table field selections

### DIFF
--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -4,6 +4,7 @@ from iceaxe.base import (
     DBModelMetaclass,
     TableBase,
 )
+from iceaxe.queries import QueryLiteral
 
 
 def test_autodetect():
@@ -30,3 +31,19 @@ def test_not_autodetect_generic(clear_registry):
         pass
 
     assert DBModelMetaclass.get_registry() == [WillAutodetect]
+
+
+def test_select_fields():
+    class TestModel(TableBase):
+        field_one: str
+        field_two: int
+
+    select_fields = TestModel.select_fields()
+
+    # The select_fields property should return a QueryLiteral that formats fields as:
+    # "{table_name}.{field_name} as {table_name}_{field_name}"
+    assert isinstance(select_fields, QueryLiteral)
+    assert (
+        str(select_fields)
+        == '"testmodel"."field_one" as "testmodel_field_one", "testmodel"."field_two" as "testmodel_field_two"'
+    )

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -135,7 +135,8 @@ class QueryBuilder(Generic[P, QueryType]):
     def select(
         # TypeVarTuples only match the typing of one-or-more elements, so we also
         # need a overloaded signature for 3 elements.
-        self, fields: tuple[T | Type[T], T2 | Type[T2], T3 | Type[T3]]
+        self,
+        fields: tuple[T | Type[T], T2 | Type[T2], T3 | Type[T3]],
     ) -> QueryBuilder[tuple[T, T2, T3], Literal["SELECT"]]: ...
 
     @overload
@@ -219,16 +220,7 @@ class QueryBuilder(Generic[P, QueryType]):
                 self.select_fields.append(literal)
                 self.select_raw.append(field)
             elif is_base_table(field):
-                table_token = QueryIdentifier(field.get_table_name())
-
-                for field_name in field.get_client_fields():
-                    field_token = QueryIdentifier(field_name)
-                    return_field = QueryIdentifier(
-                        f"{field.get_table_name()}_{field_name}"
-                    )
-                    self.select_fields.append(
-                        QueryLiteral(f"{table_token}.{field_token} as {return_field}")
-                    )
+                self.select_fields.append(field.select_fields())
                 self.select_raw.append(field)
             elif is_function_metadata(field):
                 field.local_name = f"aggregate_{self.select_aggregate_count}"


### PR DESCRIPTION
When selecting full tables, we internally rename the selected columns in the generated SQL query to differentiate between the same name field across different models. This was previously owned by the QueryBuilder. This ownership is fine for ORM based selection of model values, but was tougher to handle with manually created text sql selections.

This PR adds support for a new `Model.select_fields()` shortcut on the base model themselves, so users can use string formatting to directly place the correct table query in their manual selections.

```python
select(MyModel).text(
f"""
SELECT {MyModel.select_fields()}
FROM mymodel WHERE ...
"""
)
```