### PR TITLE
Expand class docstrings with typehints

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,3 @@ a simple poetry install. Poetry is set up to create a dynamic `setup.py` based o
 ```bash
 poetry install
 ```
-
-## TODOs
-
-- [ ] Additional documentation with usage examples.

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -530,6 +530,28 @@ async def test_refresh(db_connection: DBConnection):
 
 
 @pytest.mark.asyncio
+async def test_get(db_connection: DBConnection):
+    """
+    Test retrieving a single record by primary key using the get method.
+    """
+    # Create a test user
+    user = UserDemo(name="John Doe", email="john@example.com")
+    await db_connection.insert([user])
+    assert user.id is not None
+
+    # Test successful get
+    retrieved_user = await db_connection.get(UserDemo, user.id)
+    assert retrieved_user is not None
+    assert retrieved_user.id == user.id
+    assert retrieved_user.name == "John Doe"
+    assert retrieved_user.email == "john@example.com"
+
+    # Test get with non-existent ID
+    non_existent = await db_connection.get(UserDemo, 9999)
+    assert non_existent is None
+
+
+@pytest.mark.asyncio
 async def test_db_connection_insert_update_enum(db_connection: DBConnection):
     """
     Test that casting enum types with is working for both insert and updates.

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -16,13 +16,41 @@ from iceaxe.queries_str import QueryIdentifier, QueryLiteral
 
 @dataclass_transform(kw_only_default=True, field_specifiers=(PydanticField,))
 class DBModelMetaclass(_model_construction.ModelMetaclass):
-    _registry: list[Type["TableBase"]] = []
-    # {class: kwargs}
-    _cached_args: dict[Type["TableBase"], dict[str, Any]] = {}
+    """
+    Metaclass for database model classes that provides automatic field tracking and SQL query generation.
+    Extends Pydantic's model metaclass to add database-specific functionality.
 
-    def __new__(
-        mcs, name: str, bases: tuple, namespace: dict[str, Any], **kwargs: Any
-    ) -> type:
+    This metaclass provides:
+    - Automatic field to SQL column mapping
+    - Dynamic field access that returns query-compatible field definitions
+    - Registry tracking of all database model classes
+    - Support for generic model instantiation
+
+    Example:
+    ```python {{sticky: True}}
+    class User(TableBase):  # Uses DBModelMetaclass
+        id: int = Field(primary_key=True)
+        name: str
+        email: str | None
+
+    # Fields can be accessed for queries
+    User.id      # Returns DBFieldClassDefinition
+    User.name    # Returns DBFieldClassDefinition
+
+    # Metaclass handles model registration
+    registered_models = DBModelMetaclass.get_registry()
+    ```
+    """
+
+    _registry: list[Type["TableBase"]] = []
+    _cached_args: dict[Type["TableBase"], dict[str, Any]] = {}
+    is_constructing: bool = False
+
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        """
+        Create a new database model class with proper field tracking.
+        Handles registration of the model and processes any table-specific arguments.
+        """
         raw_kwargs = {**kwargs}
 
         mcs.is_constructing = True
@@ -59,8 +87,17 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
         return cls
 
     def __getattr__(self, key: str) -> Any:
-        # Inspired by the approach in our render logic
-        # https://github.com/piercefreeman/mountaineer/blob/fdda3a58c0fafebb43a58b4f3d410dbf44302fd6/mountaineer/render.py#L252
+        """
+        Provides dynamic access to model fields as query-compatible definitions.
+        When accessing an undefined attribute, checks if it's a model field and returns
+        a DBFieldClassDefinition if it is.
+
+        :param key: The attribute name to access
+        :type key: str
+        :return: Field definition or raises AttributeError
+        :rtype: Any
+        :raises AttributeError: If the attribute doesn't exist and isn't a model field
+        """
         if self.is_constructing:
             return super().__getattr__(key)  # type: ignore
 
@@ -78,16 +115,31 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
             raise
 
     @classmethod
-    def get_registry(cls):
+    def get_registry(cls) -> list[Type["TableBase"]]:
+        """
+        Get the set of all registered database model classes.
+
+        :return: Set of registered TableBase classes
+        :rtype: set[Type["TableBase"]]
+        """
         return cls._registry
 
     @classmethod
-    def _extract_kwarg(cls, kwargs: dict[str, Any], key: str, default: Any = None):
+    def _extract_kwarg(
+        cls, kwargs: dict[str, Any], key: str, default: Any = None
+    ) -> Any:
         """
-        Kwarg extraction that supports standard instantiation and pydantic's approach
-        for Generic models where it hydrates a fully new class in memory with the type
-        annotations set to generic values.
+        Extract a keyword argument from either standard kwargs or pydantic generic metadata.
+        Handles both normal instantiation and pydantic's generic model instantiation.
 
+        :param kwargs: Dictionary of keyword arguments
+        :type kwargs: dict[str, Any]
+        :param key: Key to extract
+        :type key: str
+        :param default: Default value if key not found
+        :type default: Any
+        :return: Extracted value or default
+        :rtype: Any
         """
         if key in kwargs:
             return kwargs.pop(key)
@@ -101,18 +153,59 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
 
     @property
     def model_fields(self) -> dict[str, DBFieldInfo]:  # type: ignore
-        # model_fields must be reimplemented in our custom metaclass, otherwise
-        # clients will get the super typehinting signature when they try
-        # to access Model.model_fields. This overrides the ClassVar typehint
-        # that's placed in the TableBase itself.
+        """
+        Get the dictionary of model fields and their definitions.
+        Overrides the ClassVar typehint from TableBase for proper typing.
+
+        :return: Dictionary of field names to field definitions
+        :rtype: dict[str, DBFieldInfo]
+        """
         return super().model_fields  # type: ignore
 
 
 class UniqueConstraint(BaseModel):
+    """
+    Represents a UNIQUE constraint in a database table.
+    Ensures that the specified combination of columns contains unique values across all rows.
+
+    :param columns: List of column names that should have unique values
+    :type columns: list[str]
+
+    Example:
+    ```python {{sticky: True}}
+    class User(TableBase):
+        email: str
+        tenant_id: int
+
+        table_args = [
+            UniqueConstraint(columns=["email", "tenant_id"])
+        ]
+    ```
+    """
+
     columns: list[str]
 
 
 class IndexConstraint(BaseModel):
+    """
+    Represents an INDEX on one or more columns in a database table.
+    Improves query performance for the specified columns.
+
+    :param columns: List of column names to create an index on
+    :type columns: list[str]
+
+    Example:
+    ```python {{sticky: True}}
+    class User(TableBase):
+        email: str
+        last_login: datetime
+
+        table_args = [
+            IndexConstraint(columns=["last_login"])
+        ]
+    ```
+    """
+
     columns: list[str]
 
 
@@ -120,6 +213,47 @@ INTERNAL_TABLE_FIELDS = ["modified_attrs"]
 
 
 class TableBase(BaseModel, metaclass=DBModelMetaclass):
+    """
+    Base class for all database table models.
+    Provides the foundation for defining database tables using Python classes with
+    type hints and field definitions.
+
+    Features:
+    - Automatic table name generation from class name
+    - Support for custom table names
+    - Tracking of modified fields for efficient updates
+    - Support for unique constraints and indexes
+    - Integration with Pydantic for validation
+
+    Class Variables:
+        table_name (ClassVar[str]): Optional custom name for the table
+        table_args (ClassVar[list[UniqueConstraint | IndexConstraint]]): Table constraints and indexes
+        model_fields (ClassVar[dict[str, DBFieldInfo]]): Dictionary of field definitions
+
+    Example:
+    ```python {{sticky: True}}
+    class User(TableBase):
+        # Custom table name (optional)
+        table_name = "users"
+
+        # Fields with types and constraints
+        id: int = Field(primary_key=True)
+        email: str = Field(unique=True)
+        name: str
+        is_active: bool = Field(default=True)
+
+        # Table-level constraints
+        table_args = [
+            UniqueConstraint(columns=["email"]),
+            IndexConstraint(columns=["name"])
+        ]
+
+    # Usage in queries
+    query = select(User).where(User.is_active == True)
+    users = await conn.execute(query)
+    ```
+    """
+
     if TYPE_CHECKING:
         model_fields: ClassVar[dict[str, DBFieldInfo]]  # type: ignore
 
@@ -129,25 +263,59 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
     # Private methods
     modified_attrs: dict[str, Any] = Field(default_factory=dict, exclude=True)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
+        """
+        Track modified attributes when fields are updated.
+        This allows for efficient database updates by only updating changed fields.
+
+        :param name: Attribute name
+        :type name: str
+        :param value: New value
+        :type value: Any
+        """
         if name in self.model_fields:
             self.modified_attrs[name] = value
         super().__setattr__(name, value)
 
     def get_modified_attributes(self) -> dict[str, Any]:
+        """
+        Get the dictionary of attributes that have been modified since instantiation
+        or the last clear_modified_attributes() call.
+
+        :return: Dictionary of modified attribute names and their values
+        :rtype: dict[str, Any]
+        """
         return self.modified_attrs
 
-    def clear_modified_attributes(self):
+    def clear_modified_attributes(self) -> None:
+        """
+        Clear the tracking of modified attributes.
+        Typically called after successfully saving changes to the database.
+        """
         self.modified_attrs.clear()
 
     @classmethod
-    def get_table_name(cls):
+    def get_table_name(cls) -> str:
+        """
+        Get the table name for this model.
+        Uses the custom table_name if set, otherwise converts the class name to lowercase.
+
+        :return: Table name to use in SQL queries
+        :rtype: str
+        """
         if cls.table_name == PydanticUndefined:
             return cls.__name__.lower()
         return cls.table_name
 
     @classmethod
-    def get_client_fields(cls):
+    def get_client_fields(cls) -> dict[str, DBFieldInfo]:
+        """
+        Get all fields that should be exposed to clients.
+        Excludes internal fields used for model functionality.
+
+        :return: Dictionary of field names to field definitions
+        :rtype: dict[str, DBFieldInfo]
+        """
         return {
             field: info
             for field, info in cls.model_fields.items()
@@ -155,15 +323,21 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         }
 
     @classmethod
-    def select_fields(cls):
+    def select_fields(cls) -> QueryLiteral:
         """
-        Returns a query selectable string that can be used to select all fields
-        from this model. This is the format that needs to be passed to our parser
-        to serialize the raw postgres field values as TableBase objects.
+        Generate a SQL-safe string for selecting all fields from this table.
+        The output format is "{table_name}.{field_name} as {table_name}_{field_name}"
+        for each field, which ensures proper field name resolution in complex queries.
 
-        The exact format is formatted as:
-        "{table_name}.{field_name} as {table_name}_{field_name}".
+        :return: SQL-safe field selection string
+        :rtype: QueryLiteral
 
+        Example:
+        ```python {{sticky: True}}
+        # For a User class with fields 'id' and 'name':
+        User.select_fields()
+        # Returns: '"users"."id" as "users_id", "users"."name" as "users_name"'
+        ```
         """
         table_token = QueryIdentifier(cls.get_table_name())
         select_fields: list[str] = []

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -26,7 +26,6 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
     - Registry tracking of all database model classes
     - Support for generic model instantiation
 
-    Example:
     ```python {{sticky: True}}
     class User(TableBase):  # Uses DBModelMetaclass
         id: int = Field(primary_key=True)
@@ -93,9 +92,7 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
         a DBFieldClassDefinition if it is.
 
         :param key: The attribute name to access
-        :type key: str
         :return: Field definition or raises AttributeError
-        :rtype: Any
         :raises AttributeError: If the attribute doesn't exist and isn't a model field
         """
         if self.is_constructing:
@@ -120,7 +117,6 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
         Get the set of all registered database model classes.
 
         :return: Set of registered TableBase classes
-        :rtype: set[Type["TableBase"]]
         """
         return cls._registry
 
@@ -133,13 +129,9 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
         Handles both normal instantiation and pydantic's generic model instantiation.
 
         :param kwargs: Dictionary of keyword arguments
-        :type kwargs: dict[str, Any]
         :param key: Key to extract
-        :type key: str
         :param default: Default value if key not found
-        :type default: Any
         :return: Extracted value or default
-        :rtype: Any
         """
         if key in kwargs:
             return kwargs.pop(key)
@@ -158,7 +150,6 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
         Overrides the ClassVar typehint from TableBase for proper typing.
 
         :return: Dictionary of field names to field definitions
-        :rtype: dict[str, DBFieldInfo]
         """
         return super().model_fields  # type: ignore
 
@@ -168,10 +159,6 @@ class UniqueConstraint(BaseModel):
     Represents a UNIQUE constraint in a database table.
     Ensures that the specified combination of columns contains unique values across all rows.
 
-    :param columns: List of column names that should have unique values
-    :type columns: list[str]
-
-    Example:
     ```python {{sticky: True}}
     class User(TableBase):
         email: str
@@ -184,6 +171,9 @@ class UniqueConstraint(BaseModel):
     """
 
     columns: list[str]
+    """
+    List of column names that should have unique values
+    """
 
 
 class IndexConstraint(BaseModel):
@@ -191,10 +181,6 @@ class IndexConstraint(BaseModel):
     Represents an INDEX on one or more columns in a database table.
     Improves query performance for the specified columns.
 
-    :param columns: List of column names to create an index on
-    :type columns: list[str]
-
-    Example:
     ```python {{sticky: True}}
     class User(TableBase):
         email: str
@@ -207,6 +193,9 @@ class IndexConstraint(BaseModel):
     """
 
     columns: list[str]
+    """
+    List of column names to create an index on
+    """
 
 
 INTERNAL_TABLE_FIELDS = ["modified_attrs"]
@@ -225,12 +214,6 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
     - Support for unique constraints and indexes
     - Integration with Pydantic for validation
 
-    Class Variables:
-        table_name (ClassVar[str]): Optional custom name for the table
-        table_args (ClassVar[list[UniqueConstraint | IndexConstraint]]): Table constraints and indexes
-        model_fields (ClassVar[dict[str, DBFieldInfo]]): Dictionary of field definitions
-
-    Example:
     ```python {{sticky: True}}
     class User(TableBase):
         # Custom table name (optional)
@@ -258,10 +241,21 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         model_fields: ClassVar[dict[str, DBFieldInfo]]  # type: ignore
 
     table_name: ClassVar[str] = PydanticUndefined  # type: ignore
+    """
+    Optional custom name for the table
+    """
+
     table_args: ClassVar[list[UniqueConstraint | IndexConstraint]] = PydanticUndefined  # type: ignore
+    """
+    Table constraints and indexes
+    """
 
     # Private methods
     modified_attrs: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    """
+    Dictionary of modified field values since instantiation or the last clear_modified_attributes() call.
+    Used to construct differential update queries.
+    """
 
     def __setattr__(self, name: str, value: Any) -> None:
         """
@@ -269,9 +263,7 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         This allows for efficient database updates by only updating changed fields.
 
         :param name: Attribute name
-        :type name: str
         :param value: New value
-        :type value: Any
         """
         if name in self.model_fields:
             self.modified_attrs[name] = value
@@ -283,7 +275,6 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         or the last clear_modified_attributes() call.
 
         :return: Dictionary of modified attribute names and their values
-        :rtype: dict[str, Any]
         """
         return self.modified_attrs
 
@@ -301,7 +292,6 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         Uses the custom table_name if set, otherwise converts the class name to lowercase.
 
         :return: Table name to use in SQL queries
-        :rtype: str
         """
         if cls.table_name == PydanticUndefined:
             return cls.__name__.lower()
@@ -314,7 +304,6 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         Excludes internal fields used for model functionality.
 
         :return: Dictionary of field names to field definitions
-        :rtype: dict[str, DBFieldInfo]
         """
         return {
             field: info
@@ -330,9 +319,7 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         for each field, which ensures proper field name resolution in complex queries.
 
         :return: SQL-safe field selection string
-        :rtype: QueryLiteral
 
-        Example:
         ```python {{sticky: True}}
         # For a User class with fields 'id' and 'name':
         User.select_fields()

--- a/iceaxe/comparison.py
+++ b/iceaxe/comparison.py
@@ -15,23 +15,6 @@ class ComparisonType(StrEnum):
     Enumeration of SQL comparison operators used in query conditions.
     These operators are used to build WHERE clauses and other conditional expressions.
 
-    Attributes:
-        EQ ("="): Equal to comparison
-        NE ("!="): Not equal to comparison
-        LT ("<"): Less than comparison
-        LE ("<="): Less than or equal to comparison
-        GT (">"): Greater than comparison
-        GE (">="): Greater than or equal to comparison
-        IN ("IN"): Check if value is in a list of values
-        NOT_IN ("NOT IN"): Check if value is not in a list of values
-        LIKE ("LIKE"): Pattern matching with wildcards
-        NOT_LIKE ("NOT LIKE"): Negated pattern matching
-        ILIKE ("ILIKE"): Case-insensitive pattern matching
-        NOT_ILIKE ("NOT ILIKE"): Negated case-insensitive pattern matching
-        IS ("IS"): NULL comparison
-        IS_NOT ("IS NOT"): NOT NULL comparison
-
-    Example:
     ```python {{sticky: True}}
     # Using comparison operators in queries:
     query = select(User).where(
@@ -43,21 +26,78 @@ class ComparisonType(StrEnum):
     """
 
     EQ = "="
+    """
+    Equal to comparison
+    """
+
     NE = "!="
+    """
+    Not equal to comparison
+    """
+
     LT = "<"
+    """
+    Less than comparison
+    """
+
     LE = "<="
+    """
+    Less than or equal to comparison
+    """
+
     GT = ">"
+    """
+    Greater than comparison
+    """
+
     GE = ">="
+    """
+    Greater than or equal to comparison
+    """
+
     IN = "IN"
+    """
+    Check if value is in a list of values
+    """
+
     NOT_IN = "NOT IN"
+    """
+    Check if value is not in a list of values
+    """
 
     LIKE = "LIKE"
+    """
+    Pattern matching with wildcards. Supports cases like:
+    - "John%" (matches "John Doe", "Johnny", etc.)
+    """
+
     NOT_LIKE = "NOT LIKE"
+    """
+    Negated pattern matching with wildcards. Supports cases like:
+    - "John%" (matches "Amy", "Bob", etc.)
+    """
+
     ILIKE = "ILIKE"
+    """
+    Case-insensitive pattern matching. Supports cases like:
+    - "john%" (matches "John Doe", "johnny", etc.)
+    """
+
     NOT_ILIKE = "NOT ILIKE"
+    """
+    Negated case-insensitive pattern matching. Supports cases like:
+    - "john%" (matches "Amy", "Bob", etc.)
+    """
 
     IS = "IS"
+    """
+    NULL comparison
+    """
+
     IS_NOT = "IS NOT"
+    """
+    NOT NULL comparison
+    """
 
 
 class ComparisonGroupType(StrEnum):
@@ -65,11 +105,6 @@ class ComparisonGroupType(StrEnum):
     Enumeration of logical operators used to combine multiple comparisons in SQL queries.
     These operators allow building complex conditions by combining multiple WHERE clauses.
 
-    Attributes:
-        AND ("AND"): Logical AND operator, all conditions must be true
-        OR ("OR"): Logical OR operator, at least one condition must be true
-
-    Example:
     ```python {{sticky: True}}
     # Combining multiple conditions:
     query = select(User).where(
@@ -90,7 +125,14 @@ class ComparisonGroupType(StrEnum):
     """
 
     AND = "AND"
+    """
+    Logical AND operator, all conditions must be true
+    """
+
     OR = "OR"
+    """
+    Logical OR operator, at least one condition must be true
+    """
 
 
 @dataclass
@@ -99,14 +141,6 @@ class FieldComparison(Generic[T]):
     Represents a single SQL comparison operation between a field and a value or another field.
     This class is typically created through the comparison operators (==, !=, >, <, etc.) on database fields.
 
-    :param left: The left side of the comparison (typically a database field)
-    :type left: T
-    :param comparison: The type of comparison to perform
-    :type comparison: ComparisonType
-    :param right: The right side of the comparison (can be a value or another field)
-    :type right: T | Any
-
-    Example:
     ```python {{sticky: True}}
     # These expressions create FieldComparison objects:
     User.age >= 21
@@ -123,17 +157,26 @@ class FieldComparison(Generic[T]):
     """
 
     left: T
-    comparison: ComparisonType
-    right: T | Any
+    """
+    The left side of the comparison (typically a database field)
+    """
 
-    def to_query(self, start: int = 1):
+    comparison: ComparisonType
+    """
+    The type of comparison to perform
+    """
+
+    right: T | Any
+    """
+    The right side of the comparison (can be a value or another field)
+    """
+
+    def to_query(self, start: int = 1) -> tuple[QueryLiteral, list[Any]]:
         """
         Converts the comparison to its SQL representation.
 
         :param start: The starting index for query parameters, defaults to 1
-        :type start: int
         :return: A tuple of the SQL query string and list of parameter values
-        :rtype: tuple[QueryLiteral, list[Any]]
         """
         variables = []
 
@@ -174,12 +217,6 @@ class FieldComparisonGroup:
     Represents a group of field comparisons combined with a logical operator (AND/OR).
     This class is typically created through the and_() and or_() functions.
 
-    :param type: The type of logical operator to use (AND/OR)
-    :type type: ComparisonGroupType
-    :param elements: List of comparisons or nested comparison groups to combine
-    :type elements: list[FieldComparison | FieldComparisonGroup]
-
-    Example:
     ```python {{sticky: True}}
     # Using and_() to create an AND group:
     query = select(User).where(
@@ -205,16 +242,22 @@ class FieldComparisonGroup:
     """
 
     type: ComparisonGroupType
-    elements: list["FieldComparison | FieldComparisonGroup"]
+    """
+    The type of logical operator to use (AND/OR)
 
-    def to_query(self, start: int = 1):
+    """
+
+    elements: list["FieldComparison | FieldComparisonGroup"]
+    """
+    List of comparisons or nested comparison groups to combine
+    """
+
+    def to_query(self, start: int = 1) -> tuple[QueryLiteral, list[Any]]:
         """
         Converts the comparison group to its SQL representation.
 
         :param start: The starting index for query parameters, defaults to 1
-        :type start: int
         :return: A tuple of the SQL query string and list of parameter values
-        :rtype: tuple[QueryLiteral, list[Any]]
         """
         queries = ""
         all_variables = []
@@ -246,7 +289,6 @@ class ComparisonBase(ABC, Generic[J]):
     to enable natural syntax for building SQL queries. It also provides additional
     methods for SQL-specific operations like IN, LIKE, and NULL comparisons.
 
-    Example:
     ```python {{sticky: True}}
     # ComparisonBase enables these operations on database fields:
     User.age >= 21
@@ -264,7 +306,6 @@ class ComparisonBase(ABC, Generic[J]):
 
         :param other: Value to compare against
         :return: A field comparison object
-        :rtype: FieldComparison
         """
         if other is None:
             return self._compare(ComparisonType.IS, None)
@@ -277,7 +318,6 @@ class ComparisonBase(ABC, Generic[J]):
 
         :param other: Value to compare against
         :return: A field comparison object
-        :rtype: FieldComparison
         """
         if other is None:
             return self._compare(ComparisonType.IS_NOT, None)
@@ -290,7 +330,6 @@ class ComparisonBase(ABC, Generic[J]):
 
         :param other: Value to compare against
         :return: A field comparison object
-        :rtype: FieldComparison
         """
         return self._compare(ComparisonType.LT, other)
 
@@ -301,7 +340,6 @@ class ComparisonBase(ABC, Generic[J]):
 
         :param other: Value to compare against
         :return: A field comparison object
-        :rtype: FieldComparison
         """
         return self._compare(ComparisonType.LE, other)
 
@@ -312,7 +350,6 @@ class ComparisonBase(ABC, Generic[J]):
 
         :param other: Value to compare against
         :return: A field comparison object
-        :rtype: FieldComparison
         """
         return self._compare(ComparisonType.GT, other)
 
@@ -323,7 +360,6 @@ class ComparisonBase(ABC, Generic[J]):
 
         :param other: Value to compare against
         :return: A field comparison object
-        :rtype: FieldComparison
         """
         return self._compare(ComparisonType.GE, other)
 
@@ -333,9 +369,7 @@ class ComparisonBase(ABC, Generic[J]):
         Checks if the field's value is in a sequence of values.
 
         :param other: Sequence of values to check against
-        :type other: Sequence[J]
         :return: A field comparison object
-        :rtype: bool
         """
         return self._compare(ComparisonType.IN, other)  # type: ignore
 
@@ -345,9 +379,7 @@ class ComparisonBase(ABC, Generic[J]):
         Checks if the field's value is not in a sequence of values.
 
         :param other: Sequence of values to check against
-        :type other: Sequence[J]
         :return: A field comparison object
-        :rtype: bool
         """
         return self._compare(ComparisonType.NOT_IN, other)  # type: ignore
 
@@ -359,9 +391,7 @@ class ComparisonBase(ABC, Generic[J]):
         Case-sensitive string pattern matching.
 
         :param other: Pattern to match against
-        :type other: str
         :return: A field comparison object
-        :rtype: bool
         """
         return self._compare(ComparisonType.LIKE, other)  # type: ignore
 
@@ -373,9 +403,7 @@ class ComparisonBase(ABC, Generic[J]):
         Case-sensitive string pattern non-matching.
 
         :param other: Pattern to match against
-        :type other: str
         :return: A field comparison object
-        :rtype: bool
         """
         return self._compare(ComparisonType.NOT_LIKE, other)  # type: ignore
 
@@ -387,9 +415,7 @@ class ComparisonBase(ABC, Generic[J]):
         Case-insensitive string pattern matching.
 
         :param other: Pattern to match against
-        :type other: str
         :return: A field comparison object
-        :rtype: bool
         """
         return self._compare(ComparisonType.ILIKE, other)  # type: ignore
 
@@ -401,9 +427,7 @@ class ComparisonBase(ABC, Generic[J]):
         Case-insensitive string pattern non-matching.
 
         :param other: Pattern to match against
-        :type other: str
         :return: A field comparison object
-        :rtype: bool
         """
         return self._compare(ComparisonType.NOT_ILIKE, other)  # type: ignore
 
@@ -412,11 +436,8 @@ class ComparisonBase(ABC, Generic[J]):
         Internal method to create a field comparison.
 
         :param comparison: Type of comparison to create
-        :type comparison: ComparisonType
         :param other: Value to compare against
-        :type other: Any
         :return: A field comparison object
-        :rtype: FieldComparison[Self]
         """
         return FieldComparison(left=self, comparison=comparison, right=other)
 
@@ -427,6 +448,5 @@ class ComparisonBase(ABC, Generic[J]):
         Must be implemented by subclasses.
 
         :return: A tuple of the SQL query string and list of parameter values
-        :rtype: tuple[QueryLiteral, list[Any]]
         """
         pass

--- a/iceaxe/comparison.py
+++ b/iceaxe/comparison.py
@@ -11,6 +11,37 @@ J = TypeVar("J")
 
 
 class ComparisonType(StrEnum):
+    """
+    Enumeration of SQL comparison operators used in query conditions.
+    These operators are used to build WHERE clauses and other conditional expressions.
+
+    Attributes:
+        EQ ("="): Equal to comparison
+        NE ("!="): Not equal to comparison
+        LT ("<"): Less than comparison
+        LE ("<="): Less than or equal to comparison
+        GT (">"): Greater than comparison
+        GE (">="): Greater than or equal to comparison
+        IN ("IN"): Check if value is in a list of values
+        NOT_IN ("NOT IN"): Check if value is not in a list of values
+        LIKE ("LIKE"): Pattern matching with wildcards
+        NOT_LIKE ("NOT LIKE"): Negated pattern matching
+        ILIKE ("ILIKE"): Case-insensitive pattern matching
+        NOT_ILIKE ("NOT ILIKE"): Negated case-insensitive pattern matching
+        IS ("IS"): NULL comparison
+        IS_NOT ("IS NOT"): NOT NULL comparison
+
+    Example:
+    ```python {{sticky: True}}
+    # Using comparison operators in queries:
+    query = select(User).where(
+        User.name == "John",  # Uses ComparisonType.EQ
+        User.age >= 21,       # Uses ComparisonType.GE
+        User.status.in_(["active", "pending"])  # Uses ComparisonType.IN
+    )
+    ```
+    """
+
     EQ = "="
     NE = "!="
     LT = "<"
@@ -30,17 +61,80 @@ class ComparisonType(StrEnum):
 
 
 class ComparisonGroupType(StrEnum):
+    """
+    Enumeration of logical operators used to combine multiple comparisons in SQL queries.
+    These operators allow building complex conditions by combining multiple WHERE clauses.
+
+    Attributes:
+        AND ("AND"): Logical AND operator, all conditions must be true
+        OR ("OR"): Logical OR operator, at least one condition must be true
+
+    Example:
+    ```python {{sticky: True}}
+    # Combining multiple conditions:
+    query = select(User).where(
+        and_(
+            User.age >= 21,
+            User.status == "active"
+        )
+    )
+
+    # Using OR conditions:
+    query = select(User).where(
+        or_(
+            User.role == "admin",
+            User.permissions.contains("manage_users")
+        )
+    )
+    ```
+    """
+
     AND = "AND"
     OR = "OR"
 
 
 @dataclass
 class FieldComparison(Generic[T]):
+    """
+    Represents a single SQL comparison operation between a field and a value or another field.
+    This class is typically created through the comparison operators (==, !=, >, <, etc.) on database fields.
+
+    :param left: The left side of the comparison (typically a database field)
+    :type left: T
+    :param comparison: The type of comparison to perform
+    :type comparison: ComparisonType
+    :param right: The right side of the comparison (can be a value or another field)
+    :type right: T | Any
+
+    Example:
+    ```python {{sticky: True}}
+    # These expressions create FieldComparison objects:
+    User.age >= 21
+    User.status.in_(["active", "pending"])
+    User.name.like("%John%")
+
+    # Direct instantiation (rarely needed):
+    comparison = FieldComparison(
+        left=User.age,
+        comparison=ComparisonType.GE,
+        right=21
+    )
+    ```
+    """
+
     left: T
     comparison: ComparisonType
     right: T | Any
 
     def to_query(self, start: int = 1):
+        """
+        Converts the comparison to its SQL representation.
+
+        :param start: The starting index for query parameters, defaults to 1
+        :type start: int
+        :return: A tuple of the SQL query string and list of parameter values
+        :rtype: tuple[QueryLiteral, list[Any]]
+        """
         variables = []
 
         field, left_vars = self.left.to_query()
@@ -76,10 +170,52 @@ class FieldComparison(Generic[T]):
 
 @dataclass
 class FieldComparisonGroup:
+    """
+    Represents a group of field comparisons combined with a logical operator (AND/OR).
+    This class is typically created through the and_() and or_() functions.
+
+    :param type: The type of logical operator to use (AND/OR)
+    :type type: ComparisonGroupType
+    :param elements: List of comparisons or nested comparison groups to combine
+    :type elements: list[FieldComparison | FieldComparisonGroup]
+
+    Example:
+    ```python {{sticky: True}}
+    # Using and_() to create an AND group:
+    query = select(User).where(
+        and_(
+            User.age >= 21,
+            User.status == "active",
+            or_(
+                User.role == "admin",
+                User.permissions.contains("manage_users")
+            )
+        )
+    )
+
+    # Direct instantiation (rarely needed):
+    group = FieldComparisonGroup(
+        type=ComparisonGroupType.AND,
+        elements=[
+            User.age >= 21,
+            User.status == "active"
+        ]
+    )
+    ```
+    """
+
     type: ComparisonGroupType
     elements: list["FieldComparison | FieldComparisonGroup"]
 
     def to_query(self, start: int = 1):
+        """
+        Converts the comparison group to its SQL representation.
+
+        :param start: The starting index for query parameters, defaults to 1
+        :type start: int
+        :return: A tuple of the SQL query string and list of parameter values
+        :rtype: tuple[QueryLiteral, list[Any]]
+        """
         queries = ""
         all_variables = []
 
@@ -102,57 +238,195 @@ class FieldComparisonGroup:
 
 
 class ComparisonBase(ABC, Generic[J]):
+    """
+    Abstract base class for database fields that can be used in comparisons.
+    Provides standard comparison operators and methods for SQL query generation.
+
+    This class implements Python's comparison magic methods (__eq__, __ne__, etc.)
+    to enable natural syntax for building SQL queries. It also provides additional
+    methods for SQL-specific operations like IN, LIKE, and NULL comparisons.
+
+    Example:
+    ```python {{sticky: True}}
+    # ComparisonBase enables these operations on database fields:
+    User.age >= 21
+    User.status == "active"
+    User.name.like("%John%")
+    User.role.in_(["admin", "moderator"])
+    User.deleted_at.is_(None)
+    ```
+    """
+
     def __eq__(self, other):  # type: ignore
+        """
+        Implements equality comparison (==).
+        Maps to SQL '=' or 'IS' for NULL comparisons.
+
+        :param other: Value to compare against
+        :return: A field comparison object
+        :rtype: FieldComparison
+        """
         if other is None:
             return self._compare(ComparisonType.IS, None)
         return self._compare(ComparisonType.EQ, other)
 
     def __ne__(self, other):  # type: ignore
+        """
+        Implements inequality comparison (!=).
+        Maps to SQL '!=' or 'IS NOT' for NULL comparisons.
+
+        :param other: Value to compare against
+        :return: A field comparison object
+        :rtype: FieldComparison
+        """
         if other is None:
             return self._compare(ComparisonType.IS_NOT, None)
         return self._compare(ComparisonType.NE, other)
 
     def __lt__(self, other):
+        """
+        Implements less than comparison (<).
+        Maps to SQL '<'.
+
+        :param other: Value to compare against
+        :return: A field comparison object
+        :rtype: FieldComparison
+        """
         return self._compare(ComparisonType.LT, other)
 
     def __le__(self, other):
+        """
+        Implements less than or equal comparison (<=).
+        Maps to SQL '<='.
+
+        :param other: Value to compare against
+        :return: A field comparison object
+        :rtype: FieldComparison
+        """
         return self._compare(ComparisonType.LE, other)
 
     def __gt__(self, other):
+        """
+        Implements greater than comparison (>).
+        Maps to SQL '>'.
+
+        :param other: Value to compare against
+        :return: A field comparison object
+        :rtype: FieldComparison
+        """
         return self._compare(ComparisonType.GT, other)
 
     def __ge__(self, other):
+        """
+        Implements greater than or equal comparison (>=).
+        Maps to SQL '>='.
+
+        :param other: Value to compare against
+        :return: A field comparison object
+        :rtype: FieldComparison
+        """
         return self._compare(ComparisonType.GE, other)
 
     def in_(self, other: Sequence[J]) -> bool:
+        """
+        Implements SQL IN operator.
+        Checks if the field's value is in a sequence of values.
+
+        :param other: Sequence of values to check against
+        :type other: Sequence[J]
+        :return: A field comparison object
+        :rtype: bool
+        """
         return self._compare(ComparisonType.IN, other)  # type: ignore
 
     def not_in(self, other: Sequence[J]) -> bool:
+        """
+        Implements SQL NOT IN operator.
+        Checks if the field's value is not in a sequence of values.
+
+        :param other: Sequence of values to check against
+        :type other: Sequence[J]
+        :return: A field comparison object
+        :rtype: bool
+        """
         return self._compare(ComparisonType.NOT_IN, other)  # type: ignore
 
     def like(
         self: "ComparisonBase[str] | ComparisonBase[str | None]", other: str
     ) -> bool:
+        """
+        Implements SQL LIKE operator for pattern matching.
+        Case-sensitive string pattern matching.
+
+        :param other: Pattern to match against
+        :type other: str
+        :return: A field comparison object
+        :rtype: bool
+        """
         return self._compare(ComparisonType.LIKE, other)  # type: ignore
 
     def not_like(
         self: "ComparisonBase[str] | ComparisonBase[str | None]", other: str
     ) -> bool:
+        """
+        Implements SQL NOT LIKE operator.
+        Case-sensitive string pattern non-matching.
+
+        :param other: Pattern to match against
+        :type other: str
+        :return: A field comparison object
+        :rtype: bool
+        """
         return self._compare(ComparisonType.NOT_LIKE, other)  # type: ignore
 
     def ilike(
         self: "ComparisonBase[str] | ComparisonBase[str | None]", other: str
     ) -> bool:
+        """
+        Implements PostgreSQL ILIKE operator.
+        Case-insensitive string pattern matching.
+
+        :param other: Pattern to match against
+        :type other: str
+        :return: A field comparison object
+        :rtype: bool
+        """
         return self._compare(ComparisonType.ILIKE, other)  # type: ignore
 
     def not_ilike(
         self: "ComparisonBase[str] | ComparisonBase[str | None]", other: str
     ) -> bool:
+        """
+        Implements PostgreSQL NOT ILIKE operator.
+        Case-insensitive string pattern non-matching.
+
+        :param other: Pattern to match against
+        :type other: str
+        :return: A field comparison object
+        :rtype: bool
+        """
         return self._compare(ComparisonType.NOT_ILIKE, other)  # type: ignore
 
     def _compare(self, comparison: ComparisonType, other: Any) -> FieldComparison[Self]:
+        """
+        Internal method to create a field comparison.
+
+        :param comparison: Type of comparison to create
+        :type comparison: ComparisonType
+        :param other: Value to compare against
+        :type other: Any
+        :return: A field comparison object
+        :rtype: FieldComparison[Self]
+        """
         return FieldComparison(left=self, comparison=comparison, right=other)
 
     @abstractmethod
     def to_query(self) -> tuple["QueryLiteral", list[Any]]:
+        """
+        Abstract method to convert the field to its SQL representation.
+        Must be implemented by subclasses.
+
+        :return: A tuple of the SQL query string and list of parameter values
+        :rtype: tuple[QueryLiteral, list[Any]]
+        """
         pass

--- a/iceaxe/functions.py
+++ b/iceaxe/functions.py
@@ -18,14 +18,6 @@ class FunctionMetadata(ComparisonBase):
     This class bridges the gap between Python function calls and their SQL representations,
     maintaining type information and original field references.
 
-    :param literal: The SQL representation of the function call
-    :type literal: QueryLiteral
-    :param original_field: The database field this function operates on
-    :type original_field: DBFieldClassDefinition
-    :param local_name: Optional alias for the function result in the query
-    :type local_name: str | None
-
-    Example:
     ```python {{sticky: True}}
     # Internal representation of function calls:
     metadata = FunctionMetadata(
@@ -38,8 +30,19 @@ class FunctionMetadata(ComparisonBase):
     """
 
     literal: QueryLiteral
+    """
+    The SQL representation of the function call
+    """
+
     original_field: DBFieldClassDefinition
+    """
+    The database field this function operates on
+    """
+
     local_name: str | None = None
+    """
+    Optional alias for the function result in the query
+    """
 
     def __init__(
         self,
@@ -56,7 +59,6 @@ class FunctionMetadata(ComparisonBase):
         Converts the function metadata to its SQL representation.
 
         :return: A tuple of the SQL literal and an empty list of variables
-        :rtype: tuple[QueryLiteral, list[Any]]
         """
         return self.literal, []
 
@@ -84,11 +86,8 @@ class FunctionBuilder:
         Creates a COUNT aggregate function call.
 
         :param field: The field to count. Can be a column or another function result
-        :type field: Any
         :return: A function metadata object that resolves to an integer count
-        :rtype: int
 
-        Example:
         ```python {{sticky: True}}
         # Count all users
         total = await conn.execute(select(func.count(User.id)))
@@ -108,11 +107,8 @@ class FunctionBuilder:
         Creates a DISTINCT function call that removes duplicate values.
 
         :param field: The field to get distinct values from
-        :type field: T
         :return: A function metadata object preserving the input type
-        :rtype: T
 
-        Example:
         ```python {{sticky: True}}
         # Get distinct status values
         statuses = await conn.execute(select(func.distinct(User.status)))
@@ -132,11 +128,8 @@ class FunctionBuilder:
         Creates a SUM aggregate function call.
 
         :param field: The numeric field to sum
-        :type field: T
         :return: A function metadata object preserving the input type
-        :rtype: T
 
-        Example:
         ```python {{sticky: True}}
         # Get total of all salaries
         total = await conn.execute(select(func.sum(Employee.salary)))
@@ -157,11 +150,8 @@ class FunctionBuilder:
         Creates an AVG aggregate function call.
 
         :param field: The numeric field to average
-        :type field: T
         :return: A function metadata object preserving the input type
-        :rtype: T
 
-        Example:
         ```python {{sticky: True}}
         # Get average age of all users
         avg_age = await conn.execute(select(func.avg(User.age)))
@@ -182,11 +172,8 @@ class FunctionBuilder:
         Creates a MAX aggregate function call.
 
         :param field: The field to get the maximum value from
-        :type field: T
         :return: A function metadata object preserving the input type
-        :rtype: T
 
-        Example:
         ```python {{sticky: True}}
         # Get highest salary
         highest = await conn.execute(select(func.max(Employee.salary)))
@@ -207,11 +194,8 @@ class FunctionBuilder:
         Creates a MIN aggregate function call.
 
         :param field: The field to get the minimum value from
-        :type field: T
         :return: A function metadata object preserving the input type
-        :rtype: T
 
-        Example:
         ```python {{sticky: True}}
         # Get lowest salary
         lowest = await conn.execute(select(func.min(Employee.salary)))
@@ -233,9 +217,7 @@ class FunctionBuilder:
         Handles both raw columns and nested function calls.
 
         :param field: The field to convert
-        :type field: Any
         :return: A FunctionMetadata instance
-        :rtype: FunctionMetadata
         :raises ValueError: If the field cannot be converted to a column
         """
         if is_function_metadata(field):

--- a/iceaxe/functions.py
+++ b/iceaxe/functions.py
@@ -13,6 +13,30 @@ T = TypeVar("T")
 
 
 class FunctionMetadata(ComparisonBase):
+    """
+    Represents metadata for SQL aggregate functions and other SQL function operations.
+    This class bridges the gap between Python function calls and their SQL representations,
+    maintaining type information and original field references.
+
+    :param literal: The SQL representation of the function call
+    :type literal: QueryLiteral
+    :param original_field: The database field this function operates on
+    :type original_field: DBFieldClassDefinition
+    :param local_name: Optional alias for the function result in the query
+    :type local_name: str | None
+
+    Example:
+    ```python {{sticky: True}}
+    # Internal representation of function calls:
+    metadata = FunctionMetadata(
+        literal=QueryLiteral("count(users.id)"),
+        original_field=User.id,
+        local_name="user_count"
+    )
+    # Used in query: SELECT count(users.id) AS user_count
+    ```
+    """
+
     literal: QueryLiteral
     original_field: DBFieldClassDefinition
     local_name: str | None = None
@@ -28,41 +52,192 @@ class FunctionMetadata(ComparisonBase):
         self.local_name = local_name
 
     def to_query(self):
+        """
+        Converts the function metadata to its SQL representation.
+
+        :return: A tuple of the SQL literal and an empty list of variables
+        :rtype: tuple[QueryLiteral, list[Any]]
+        """
         return self.literal, []
 
 
 class FunctionBuilder:
+    """
+    Builder class for SQL aggregate functions and other SQL operations.
+    Provides a Pythonic interface for creating SQL function calls with proper type hints.
+
+    This class is typically accessed through the global `func` instance:
+    ```python {{sticky: True}}
+    from iceaxe import func
+
+    # In a query:
+    query = select((
+        User.name,
+        func.count(User.id),
+        func.max(User.age)
+    ))
+    ```
+    """
+
     def count(self, field: Any) -> int:
+        """
+        Creates a COUNT aggregate function call.
+
+        :param field: The field to count. Can be a column or another function result
+        :type field: Any
+        :return: A function metadata object that resolves to an integer count
+        :rtype: int
+
+        Example:
+        ```python {{sticky: True}}
+        # Count all users
+        total = await conn.execute(select(func.count(User.id)))
+
+        # Count distinct values
+        unique = await conn.execute(
+            select(func.count(func.distinct(User.status)))
+        )
+        ```
+        """
         metadata = self._column_to_metadata(field)
         metadata.literal = QueryLiteral(f"count({metadata.literal})")
         return cast(int, metadata)
 
     def distinct(self, field: T) -> T:
+        """
+        Creates a DISTINCT function call that removes duplicate values.
+
+        :param field: The field to get distinct values from
+        :type field: T
+        :return: A function metadata object preserving the input type
+        :rtype: T
+
+        Example:
+        ```python {{sticky: True}}
+        # Get distinct status values
+        statuses = await conn.execute(select(func.distinct(User.status)))
+
+        # Count distinct values
+        unique_count = await conn.execute(
+            select(func.count(func.distinct(User.status)))
+        )
+        ```
+        """
         metadata = self._column_to_metadata(field)
         metadata.literal = QueryLiteral(f"distinct {metadata.literal}")
         return cast(T, metadata)
 
     def sum(self, field: T) -> T:
+        """
+        Creates a SUM aggregate function call.
+
+        :param field: The numeric field to sum
+        :type field: T
+        :return: A function metadata object preserving the input type
+        :rtype: T
+
+        Example:
+        ```python {{sticky: True}}
+        # Get total of all salaries
+        total = await conn.execute(select(func.sum(Employee.salary)))
+
+        # Sum with grouping
+        by_dept = await conn.execute(
+            select((Department.name, func.sum(Employee.salary)))
+            .group_by(Department.name)
+        )
+        ```
+        """
         metadata = self._column_to_metadata(field)
         metadata.literal = QueryLiteral(f"sum({metadata.literal})")
         return cast(T, metadata)
 
     def avg(self, field: T) -> T:
+        """
+        Creates an AVG aggregate function call.
+
+        :param field: The numeric field to average
+        :type field: T
+        :return: A function metadata object preserving the input type
+        :rtype: T
+
+        Example:
+        ```python {{sticky: True}}
+        # Get average age of all users
+        avg_age = await conn.execute(select(func.avg(User.age)))
+
+        # Average with grouping
+        by_dept = await conn.execute(
+            select((Department.name, func.avg(Employee.salary)))
+            .group_by(Department.name)
+        )
+        ```
+        """
         metadata = self._column_to_metadata(field)
         metadata.literal = QueryLiteral(f"avg({metadata.literal})")
         return cast(T, metadata)
 
     def max(self, field: T) -> T:
+        """
+        Creates a MAX aggregate function call.
+
+        :param field: The field to get the maximum value from
+        :type field: T
+        :return: A function metadata object preserving the input type
+        :rtype: T
+
+        Example:
+        ```python {{sticky: True}}
+        # Get highest salary
+        highest = await conn.execute(select(func.max(Employee.salary)))
+
+        # Max with grouping
+        by_dept = await conn.execute(
+            select((Department.name, func.max(Employee.salary)))
+            .group_by(Department.name)
+        )
+        ```
+        """
         metadata = self._column_to_metadata(field)
         metadata.literal = QueryLiteral(f"max({metadata.literal})")
         return cast(T, metadata)
 
     def min(self, field: T) -> T:
+        """
+        Creates a MIN aggregate function call.
+
+        :param field: The field to get the minimum value from
+        :type field: T
+        :return: A function metadata object preserving the input type
+        :rtype: T
+
+        Example:
+        ```python {{sticky: True}}
+        # Get lowest salary
+        lowest = await conn.execute(select(func.min(Employee.salary)))
+
+        # Min with grouping
+        by_dept = await conn.execute(
+            select((Department.name, func.min(Employee.salary)))
+            .group_by(Department.name)
+        )
+        ```
+        """
         metadata = self._column_to_metadata(field)
         metadata.literal = QueryLiteral(f"min({metadata.literal})")
         return cast(T, metadata)
 
     def _column_to_metadata(self, field: Any) -> FunctionMetadata:
+        """
+        Internal helper method to convert a field to FunctionMetadata.
+        Handles both raw columns and nested function calls.
+
+        :param field: The field to convert
+        :type field: Any
+        :return: A FunctionMetadata instance
+        :rtype: FunctionMetadata
+        :raises ValueError: If the field cannot be converted to a column
+        """
         if is_function_metadata(field):
             return field
         elif is_column(field):

--- a/iceaxe/migrations/generator.py
+++ b/iceaxe/migrations/generator.py
@@ -51,7 +51,6 @@ class MigrationGenerator:
     - Type creation and updates
     - Import tracking for required dependencies
 
-    Example:
     ```python {{sticky: True}}
     # Generate a new migration
     generator = MigrationGenerator()
@@ -100,17 +99,11 @@ class MigrationGenerator:
         Generate a new migration file by comparing two database states.
 
         :param down_objects_with_dependencies: Current database state with object dependencies
-        :type down_objects_with_dependencies: Sequence[tuple[DBObject, Sequence[DBObject | DBObjectPointer]]]
         :param up_objects_with_dependencies: Desired database state with object dependencies
-        :type up_objects_with_dependencies: Sequence[tuple[DBObject, Sequence[DBObject | DBObjectPointer]]]
         :param down_revision: ID of the previous migration this one builds upon
-        :type down_revision: str | None
         :param user_message: Optional description of the migration's purpose
-        :type user_message: str | None
         :return: A tuple of (generated migration code, new revision ID)
-        :rtype: tuple[str, str]
 
-        Example:
         ```python {{sticky: True}}
         # Generate migration for schema change
         generator = MigrationGenerator()
@@ -196,11 +189,8 @@ class MigrationGenerator:
         Handles both actual database operations and comments.
 
         :param actions: List of actions to convert to code
-        :type actions: list[DryRunAction | DryRunComment]
         :return: List of Python code lines
-        :rtype: list[str]
 
-        Example:
         ```python {{sticky: True}}
         generator = MigrationGenerator()
         code_lines = generator.actions_to_code([
@@ -269,13 +259,10 @@ class MigrationGenerator:
         - None values
 
         :param value: The value to format as code
-        :type value: Any
         :return: A string representation of the value as valid Python code
-        :rtype: str
         :raises ValueError: If the value type is not supported
         :raises TypeError: If a BaseModel/dataclass value is a class instead of an instance
 
-        Example:
         ```python {{sticky: True}}
         generator = MigrationGenerator()
 
@@ -364,12 +351,9 @@ class MigrationGenerator:
         Manages the import statements needed for types and functions used in the migration.
 
         :param value: The class, function, or module to import
-        :type value: Type[Any] | Callable | ModuleType
         :param explicit: Optional explicit import path override
-        :type explicit: str | None
         :raises ValueError: If explicit import is required for a module but not provided
 
-        Example:
         ```python {{sticky: True}}
         generator = MigrationGenerator()
 
@@ -404,13 +388,9 @@ class MigrationGenerator:
         Each level is 4 spaces.
 
         :param code: List of code lines to indent
-        :type code: list[str]
         :param indent: Number of indentation levels
-        :type indent: int
         :return: The indented code as a single string
-        :rtype: str
 
-        Example:
         ```python {{sticky: True}}
         generator = MigrationGenerator()
         code = generator.indent_code(

--- a/iceaxe/postgres.py
+++ b/iceaxe/postgres.py
@@ -12,8 +12,46 @@ class PostgresFieldBase(BaseModel):
 
 
 class PostgresDateTime(PostgresFieldBase):
+    """
+    Extension to Python's datetime type that specifies additional Postgres-specific configuration.
+    Used to customize the timezone behavior of datetime fields in Postgres.
+
+    :param timezone: Whether the datetime field should include timezone information in Postgres.
+                    If True, maps to TIMESTAMP WITH TIME ZONE.
+                    If False, maps to TIMESTAMP WITHOUT TIME ZONE.
+                    Defaults to False.
+    :type timezone: bool
+
+    Example:
+    ```python {{sticky: True}}
+    from iceaxe import Field, TableBase
+    class Event(TableBase):
+        id: int = Field(primary_key=True)
+        created_at: datetime = Field(postgres_config=PostgresDateTime(timezone=True))
+    ```
+    """
+
     timezone: bool = False
 
 
 class PostgresTime(PostgresFieldBase):
+    """
+    Extension to Python's time type that specifies additional Postgres-specific configuration.
+    Used to customize the timezone behavior of time fields in Postgres.
+
+    :param timezone: Whether the time field should include timezone information in Postgres.
+                    If True, maps to TIME WITH TIME ZONE.
+                    If False, maps to TIME WITHOUT TIME ZONE.
+                    Defaults to False.
+    :type timezone: bool
+
+    Example:
+    ```python {{sticky: True}}
+    from iceaxe import Field, TableBase
+    class Schedule(TableBase):
+        id: int = Field(primary_key=True)
+        start_time: time = Field(postgres_config=PostgresTime(timezone=True))
+    ```
+    """
+
     timezone: bool = False

--- a/iceaxe/postgres.py
+++ b/iceaxe/postgres.py
@@ -16,13 +16,6 @@ class PostgresDateTime(PostgresFieldBase):
     Extension to Python's datetime type that specifies additional Postgres-specific configuration.
     Used to customize the timezone behavior of datetime fields in Postgres.
 
-    :param timezone: Whether the datetime field should include timezone information in Postgres.
-                    If True, maps to TIMESTAMP WITH TIME ZONE.
-                    If False, maps to TIMESTAMP WITHOUT TIME ZONE.
-                    Defaults to False.
-    :type timezone: bool
-
-    Example:
     ```python {{sticky: True}}
     from iceaxe import Field, TableBase
     class Event(TableBase):
@@ -32,6 +25,13 @@ class PostgresDateTime(PostgresFieldBase):
     """
 
     timezone: bool = False
+    """
+    Whether the datetime field should include timezone information in Postgres.
+        If True, maps to TIMESTAMP WITH TIME ZONE.
+        If False, maps to TIMESTAMP WITHOUT TIME ZONE.
+        Defaults to False.
+
+    """
 
 
 class PostgresTime(PostgresFieldBase):
@@ -39,13 +39,6 @@ class PostgresTime(PostgresFieldBase):
     Extension to Python's time type that specifies additional Postgres-specific configuration.
     Used to customize the timezone behavior of time fields in Postgres.
 
-    :param timezone: Whether the time field should include timezone information in Postgres.
-                    If True, maps to TIME WITH TIME ZONE.
-                    If False, maps to TIME WITHOUT TIME ZONE.
-                    Defaults to False.
-    :type timezone: bool
-
-    Example:
     ```python {{sticky: True}}
     from iceaxe import Field, TableBase
     class Schedule(TableBase):
@@ -55,3 +48,10 @@ class PostgresTime(PostgresFieldBase):
     """
 
     timezone: bool = False
+    """
+    Whether the time field should include timezone information in Postgres.
+        If True, maps to TIME WITH TIME ZONE.
+        If False, maps to TIME WITHOUT TIME ZONE.
+        Defaults to False.
+
+    """

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -492,11 +492,8 @@ def and_(
     All conditions must be true for the group to be true.
 
     :param conditions: Variable number of conditions to combine
-    :type conditions: bool
     :return: A field comparison group object
-    :rtype: bool
 
-    Example:
     ```python {{sticky: True}}
     query = select(User).where(
         and_(
@@ -526,11 +523,8 @@ def or_(
     At least one condition must be true for the group to be true.
 
     :param conditions: Variable number of conditions to combine
-    :type conditions: bool
     :return: A field comparison group object
-    :rtype: bool
 
-    Example:
     ```python {{sticky: True}}
     query = select(User).where(
         or_(
@@ -605,11 +599,8 @@ def select(
                   - A single field or model class (e.g., User.id or User)
                   - A tuple of fields (e.g., (User.id, User.name))
                   - A tuple of model classes (e.g., (User, Post))
-    :type fields: T | Type[T] | tuple[T | Type[T], ...] | tuple[T | Type[T], T2 | Type[T2], ...]
     :return: A QueryBuilder instance configured for SELECT operations
-    :rtype: QueryBuilder[T | tuple[T, ...], Literal["SELECT"]]
 
-    Example:
     ```python {{sticky: True}}
     # Select all fields from User
     users = await conn.execute(select(User))
@@ -635,11 +626,8 @@ def update(model: Type[TableBase]) -> QueryBuilder[None, Literal["UPDATE"]]:
     that creates and returns a new QueryBuilder instance.
 
     :param model: The model class representing the table to update
-    :type model: Type[TableBase]
     :return: A QueryBuilder instance configured for UPDATE operations
-    :rtype: QueryBuilder[None, Literal["UPDATE"]]
 
-    Example:
     ```python {{sticky: True}}
     # Update all users' status
     await conn.execute(
@@ -666,11 +654,8 @@ def delete(model: Type[TableBase]) -> QueryBuilder[None, Literal["DELETE"]]:
     that creates and returns a new QueryBuilder instance.
 
     :param model: The model class representing the table to delete from
-    :type model: Type[TableBase]
     :return: A QueryBuilder instance configured for DELETE operations
-    :rtype: QueryBuilder[None, Literal["DELETE"]]
 
-    Example:
     ```python {{sticky: True}}
     # Delete inactive users
     await conn.execute(

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -487,6 +487,26 @@ class QueryBuilder(Generic[P, QueryType]):
 def and_(
     *conditions: bool,
 ) -> bool:
+    """
+    Combines multiple conditions with logical AND.
+    All conditions must be true for the group to be true.
+
+    :param conditions: Variable number of conditions to combine
+    :type conditions: bool
+    :return: A field comparison group object
+    :rtype: bool
+
+    Example:
+    ```python {{sticky: True}}
+    query = select(User).where(
+        and_(
+            User.age >= 21,
+            User.status == "active",
+            User.role == "member"
+        )
+    )
+    ```
+    """
     field_comparisons: list[FieldComparison | FieldComparisonGroup] = []
     for condition in conditions:
         if not is_comparison(condition) and not is_comparison_group(condition):
@@ -501,6 +521,28 @@ def and_(
 def or_(
     *conditions: bool,
 ) -> bool:
+    """
+    Combines multiple conditions with logical OR.
+    At least one condition must be true for the group to be true.
+
+    :param conditions: Variable number of conditions to combine
+    :type conditions: bool
+    :return: A field comparison group object
+    :rtype: bool
+
+    Example:
+    ```python {{sticky: True}}
+    query = select(User).where(
+        or_(
+            User.role == "admin",
+            and_(
+                User.role == "moderator",
+                User.permissions.contains("manage_users")
+            )
+        )
+    )
+    ```
+    """
     field_comparisons: list[FieldComparison | FieldComparisonGroup] = []
     for condition in conditions:
         if not is_comparison(condition) and not is_comparison_group(condition):
@@ -556,23 +598,96 @@ def select(
     | QueryBuilder[tuple[T, T2, T3, *Ts], Literal["SELECT"]]
 ):
     """
-    Shortcut to create a SELECT query with a new QueryBuilder.
+    Creates a SELECT query to fetch data from the database. This is a shortcut function that creates
+    and returns a new QueryBuilder instance.
 
+    :param fields: The fields to select. Can be:
+                  - A single field or model class (e.g., User.id or User)
+                  - A tuple of fields (e.g., (User.id, User.name))
+                  - A tuple of model classes (e.g., (User, Post))
+    :type fields: T | Type[T] | tuple[T | Type[T], ...] | tuple[T | Type[T], T2 | Type[T2], ...]
+    :return: A QueryBuilder instance configured for SELECT operations
+    :rtype: QueryBuilder[T | tuple[T, ...], Literal["SELECT"]]
+
+    Example:
+    ```python {{sticky: True}}
+    # Select all fields from User
+    users = await conn.execute(select(User))
+
+    # Select specific fields
+    results = await conn.execute(select((User.id, User.name)))
+
+    # Select with conditions
+    active_users = await conn.execute(
+        select(User)
+        .where(User.is_active == True)
+        .order_by(User.created_at, "DESC")
+        .limit(10)
+    )
+    ```
     """
     return QueryBuilder().select(fields)
 
 
 def update(model: Type[TableBase]) -> QueryBuilder[None, Literal["UPDATE"]]:
     """
-    Shortcut to create an UPDATE query with a new QueryBuilder.
+    Creates an UPDATE query to modify existing records in the database. This is a shortcut function
+    that creates and returns a new QueryBuilder instance.
 
+    :param model: The model class representing the table to update
+    :type model: Type[TableBase]
+    :return: A QueryBuilder instance configured for UPDATE operations
+    :rtype: QueryBuilder[None, Literal["UPDATE"]]
+
+    Example:
+    ```python {{sticky: True}}
+    # Update all users' status
+    await conn.execute(
+        update(User)
+        .set(User.status, "inactive")
+        .where(User.last_login < datetime.now() - timedelta(days=30))
+    )
+
+    # Update multiple fields with conditions
+    await conn.execute(
+        update(User)
+        .set(User.verified, True)
+        .set(User.verification_date, datetime.now())
+        .where(User.email_confirmed == True)
+    )
+    ```
     """
     return QueryBuilder().update(model)
 
 
 def delete(model: Type[TableBase]) -> QueryBuilder[None, Literal["DELETE"]]:
     """
-    Shortcut to create a DELETE query with a new QueryBuilder.
+    Creates a DELETE query to remove records from the database. This is a shortcut function
+    that creates and returns a new QueryBuilder instance.
 
+    :param model: The model class representing the table to delete from
+    :type model: Type[TableBase]
+    :return: A QueryBuilder instance configured for DELETE operations
+    :rtype: QueryBuilder[None, Literal["DELETE"]]
+
+    Example:
+    ```python {{sticky: True}}
+    # Delete inactive users
+    await conn.execute(
+        delete(User)
+        .where(User.is_active == False)
+    )
+
+    # Delete with complex conditions
+    await conn.execute(
+        delete(User)
+        .where(
+            and_(
+                User.created_at < datetime.now() - timedelta(days=90),
+                User.email_confirmed == False
+            )
+        )
+    )
+    ```
     """
     return QueryBuilder().delete(model)

--- a/iceaxe/queries_str.py
+++ b/iceaxe/queries_str.py
@@ -9,13 +9,9 @@ class QueryElementBase(ABC):
     This class provides the foundation for handling different types of SQL elements
     (like identifiers and literals) with their specific escaping and formatting rules.
 
-    :param value: The raw string value to be processed
-    :type value: str
-
     The class implements equality comparisons based on the processed string representation,
     making it suitable for comparing query elements in test assertions and caching.
 
-    Example:
     ```python {{sticky: True}}
     # Base class is not used directly, but through its subclasses:
     table_name = QueryIdentifier("users")  # -> "users"
@@ -24,6 +20,9 @@ class QueryElementBase(ABC):
     """
 
     def __init__(self, value: str):
+        """
+        :param value: The raw string value to be processed
+        """
         self._value = self.process_value(value)
 
     @abstractmethod
@@ -33,9 +32,7 @@ class QueryElementBase(ABC):
         Must be implemented by subclasses.
 
         :param value: The raw string value to process
-        :type value: str
         :return: The processed string value
-        :rtype: str
         """
         pass
 
@@ -60,10 +57,6 @@ class QueryIdentifier(QueryElementBase):
     When used, the identifier is automatically wrapped in double quotes, making it
     safe for use in queries even if it contains special characters or SQL keywords.
 
-    :param value: The identifier name (e.g., table name, column name)
-    :type value: str
-
-    Example:
     ```python {{sticky: True}}
     # In a query builder context:
     table = QueryIdentifier("user_data")
@@ -89,14 +82,10 @@ class QueryLiteral(QueryElementBase):
     This class is used for parts of the query that are already properly formatted and
     should not be modified, such as SQL functions, operators, or pre-processed strings.
 
-    :param value: The raw SQL string to be included in the query
-    :type value: str
-
     Warning:
         Be careful when using QueryLiteral with user input, as it bypasses SQL escaping.
         It should primarily be used for trusted, programmatically generated SQL components.
 
-    Example:
     ```python {{sticky: True}}
     # Safe usage with SQL functions:
     count = QueryLiteral("COUNT(*)")

--- a/iceaxe/queries_str.py
+++ b/iceaxe/queries_str.py
@@ -4,11 +4,39 @@ from abc import ABC, abstractmethod
 
 
 class QueryElementBase(ABC):
+    """
+    Abstract base class for SQL query elements that require special string processing.
+    This class provides the foundation for handling different types of SQL elements
+    (like identifiers and literals) with their specific escaping and formatting rules.
+
+    :param value: The raw string value to be processed
+    :type value: str
+
+    The class implements equality comparisons based on the processed string representation,
+    making it suitable for comparing query elements in test assertions and caching.
+
+    Example:
+    ```python {{sticky: True}}
+    # Base class is not used directly, but through its subclasses:
+    table_name = QueryIdentifier("users")  # -> "users"
+    raw_sql = QueryLiteral("COUNT(*)")    # -> COUNT(*)
+    ```
+    """
+
     def __init__(self, value: str):
         self._value = self.process_value(value)
 
     @abstractmethod
     def process_value(self, value: str) -> str:
+        """
+        Process the input value according to the specific rules of the query element type.
+        Must be implemented by subclasses.
+
+        :param value: The raw string value to process
+        :type value: str
+        :return: The processed string value
+        :rtype: str
+        """
         pass
 
     def __eq__(self, compare):
@@ -25,10 +53,62 @@ class QueryElementBase(ABC):
 
 
 class QueryIdentifier(QueryElementBase):
+    """
+    Represents a SQL identifier (table name, column name, etc.) that needs to be
+    properly quoted to prevent SQL injection and handle special characters.
+
+    When used, the identifier is automatically wrapped in double quotes, making it
+    safe for use in queries even if it contains special characters or SQL keywords.
+
+    :param value: The identifier name (e.g., table name, column name)
+    :type value: str
+
+    Example:
+    ```python {{sticky: True}}
+    # In a query builder context:
+    table = QueryIdentifier("user_data")
+    column = QueryIdentifier("email_address")
+    print(f"SELECT {column} FROM {table}")
+    # -> SELECT "email_address" FROM "user_data"
+
+    # Handles special characters and keywords safely:
+    reserved = QueryIdentifier("group")
+    print(str(reserved))  # -> "group"
+    ```
+    """
+
     def process_value(self, value: str):
         return f'"{value}"'
 
 
 class QueryLiteral(QueryElementBase):
+    """
+    Represents a raw SQL literal that should be included in the query exactly as provided,
+    without any additional processing or escaping.
+
+    This class is used for parts of the query that are already properly formatted and
+    should not be modified, such as SQL functions, operators, or pre-processed strings.
+
+    :param value: The raw SQL string to be included in the query
+    :type value: str
+
+    Warning:
+        Be careful when using QueryLiteral with user input, as it bypasses SQL escaping.
+        It should primarily be used for trusted, programmatically generated SQL components.
+
+    Example:
+    ```python {{sticky: True}}
+    # Safe usage with SQL functions:
+    count = QueryLiteral("COUNT(*)")
+    print(f"SELECT {count} FROM users")
+    # -> SELECT COUNT(*) FROM users
+
+    # Complex SQL expressions:
+    case = QueryLiteral("CASE WHEN age > 18 THEN 'adult' ELSE 'minor' END")
+    print(f"SELECT name, {case} FROM users")
+    # -> SELECT name, CASE WHEN age > 18 THEN 'adult' ELSE 'minor' END FROM users
+    ```
+    """
+
     def process_value(self, value: str):
         return value

--- a/iceaxe/session.py
+++ b/iceaxe/session.py
@@ -333,14 +333,10 @@ class DBConnection:
         It automatically constructs and executes a SELECT query with a WHERE clause matching the primary key.
 
         :param model: The model class to query (must be a subclass of TableBase)
-        :type model: Type[TableType]
         :param primary_key_value: The value of the primary key to look up
-        :type primary_key_value: Any
         :return: The model instance if found, None if no record matches the primary key
-        :rtype: TableType | None
         :raises ValueError: If the model has no primary key defined
 
-        Example:
         ```python {{sticky: True}}
         class User(TableBase):
             id: int = Field(primary_key=True)


### PR DESCRIPTION
Add additional class and function docstrings to provide additional usage guidelines.

Add a shortcut DBConnection.get() function for the common case of needing to retrieve only one object by its primary key. This makes the following blocks of code interchangable:

```python
query = select(MyModel).where(MyModel.id == my_id)
elements = db_connection.exec(query)
element = elements[0] if elements else None
```

```
python
element = db_connection.get(MyModel, my_id)
```