### PR TITLE
Expose sql generator

### DIFF
--- a/iceaxe/__init__.py
+++ b/iceaxe/__init__.py
@@ -14,5 +14,6 @@ from .queries import (
     select as select,
     update as update,
 )
+from .queries_str import sql as sql
 from .session import DBConnection as DBConnection
 from .typing import column as column

--- a/iceaxe/__tests__/conf_models.py
+++ b/iceaxe/__tests__/conf_models.py
@@ -89,6 +89,20 @@ class FunctionTestModel(TableBase):
     timestamp_str: str
 
 
+class TestModelA(TableBase):
+    id: int = Field(primary_key=True, default=None)
+    name: str
+    description: str
+    code: str = Field(unique=True)
+
+
+class TestModelB(TableBase):
+    id: int = Field(primary_key=True, default=None)
+    name: str
+    category: str
+    code: str = Field(unique=True)
+
+
 @contextmanager
 def run_profile(request):
     TESTS_ROOT = Path.cwd()

--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -4,7 +4,6 @@ from iceaxe.base import (
     DBModelMetaclass,
     TableBase,
 )
-from iceaxe.queries import QueryLiteral
 
 
 def test_autodetect():
@@ -31,19 +30,3 @@ def test_not_autodetect_generic(clear_registry):
         pass
 
     assert DBModelMetaclass.get_registry() == [WillAutodetect]
-
-
-def test_select_fields():
-    class TestModel(TableBase):
-        field_one: str
-        field_two: int
-
-    select_fields = TestModel.select_fields()
-
-    # The select_fields property should return a QueryLiteral that formats fields as:
-    # "{table_name}.{field_name} as {table_name}_{field_name}"
-    assert isinstance(select_fields, QueryLiteral)
-    assert (
-        str(select_fields)
-        == '"testmodel"."field_one" as "testmodel_field_one", "testmodel"."field_two" as "testmodel_field_two"'
-    )

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -25,13 +25,16 @@ def test_select():
 
 def test_select_single_field():
     new_query = QueryBuilder().select(UserDemo.email)
-    assert new_query.build() == ('SELECT "userdemo"."email" FROM "userdemo"', [])
+    assert new_query.build() == (
+        'SELECT "userdemo"."email" AS "userdemo_email" FROM "userdemo"',
+        [],
+    )
 
 
 def test_select_multiple_fields():
     new_query = QueryBuilder().select((UserDemo.id, UserDemo.name, UserDemo.email))
     assert new_query.build() == (
-        'SELECT "userdemo"."id", "userdemo"."name", "userdemo"."email" FROM "userdemo"',
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS "userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo"',
         [],
     )
 
@@ -39,7 +42,7 @@ def test_select_multiple_fields():
 def test_where():
     new_query = QueryBuilder().select(UserDemo.id).where(UserDemo.id > 0)
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" WHERE "userdemo"."id" > $1',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" WHERE "userdemo"."id" > $1',
         [0],
     )
 
@@ -49,7 +52,7 @@ def test_where_columns():
         QueryBuilder().select(UserDemo.id).where(UserDemo.name == UserDemo.email)
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" WHERE "userdemo"."name" = "userdemo"."email"',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" WHERE "userdemo"."name" = "userdemo"."email"',
         [],
     )
 
@@ -61,7 +64,7 @@ def test_multiple_where_conditions():
         .where(UserDemo.id > 0, UserDemo.name == "John")
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" WHERE "userdemo"."id" > $1 AND "userdemo"."name" = $2',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" WHERE "userdemo"."id" > $1 AND "userdemo"."name" = $2',
         [0, "John"],
     )
 
@@ -69,7 +72,7 @@ def test_multiple_where_conditions():
 def test_order_by():
     new_query = QueryBuilder().select(UserDemo.id).order_by(UserDemo.id, "DESC")
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" ORDER BY "userdemo"."id" DESC',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" ORDER BY "userdemo"."id" DESC',
         [],
     )
 
@@ -82,7 +85,7 @@ def test_multiple_order_by():
         .order_by(UserDemo.name, "ASC")
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" ORDER BY "userdemo"."id" DESC, "userdemo"."name" ASC',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" ORDER BY "userdemo"."id" DESC, "userdemo"."name" ASC',
         [],
     )
 
@@ -94,7 +97,7 @@ def test_join():
         .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id)
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id", "artifactdemo"."title" FROM "userdemo" INNER JOIN artifactdemo ON "userdemo"."id" = "artifactdemo"."user_id"',
+        'SELECT "userdemo"."id" AS "userdemo_id", "artifactdemo"."title" AS "artifactdemo_title" FROM "userdemo" INNER JOIN "artifactdemo" ON "userdemo"."id" = "artifactdemo"."user_id"',
         [],
     )
 
@@ -106,25 +109,31 @@ def test_left_join():
         .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, "LEFT")
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id", "artifactdemo"."title" FROM "userdemo" LEFT JOIN artifactdemo ON "userdemo"."id" = "artifactdemo"."user_id"',
+        'SELECT "userdemo"."id" AS "userdemo_id", "artifactdemo"."title" AS "artifactdemo_title" FROM "userdemo" LEFT JOIN "artifactdemo" ON "userdemo"."id" = "artifactdemo"."user_id"',
         [],
     )
 
 
 def test_limit():
     new_query = QueryBuilder().select(UserDemo.id).limit(10)
-    assert new_query.build() == ('SELECT "userdemo"."id" FROM "userdemo" LIMIT 10', [])
+    assert new_query.build() == (
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" LIMIT 10',
+        [],
+    )
 
 
 def test_offset():
     new_query = QueryBuilder().select(UserDemo.id).offset(5)
-    assert new_query.build() == ('SELECT "userdemo"."id" FROM "userdemo" OFFSET 5', [])
+    assert new_query.build() == (
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" OFFSET 5',
+        [],
+    )
 
 
 def test_limit_and_offset():
     new_query = QueryBuilder().select(UserDemo.id).limit(10).offset(5)
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" LIMIT 10 OFFSET 5',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" LIMIT 10 OFFSET 5',
         [],
     )
 
@@ -136,7 +145,7 @@ def test_group_by():
         .group_by(UserDemo.name)
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."name", count("userdemo"."id") AS aggregate_0 FROM "userdemo" GROUP BY "userdemo"."name"',
+        'SELECT "userdemo"."name" AS "userdemo_name", count("userdemo"."id") AS aggregate_0 FROM "userdemo" GROUP BY "userdemo"."name"',
         [],
     )
 
@@ -149,7 +158,7 @@ def test_update():
         .where(UserDemo.id == 1)
     )
     assert new_query.build() == (
-        'UPDATE "userdemo" SET "userdemo"."name" = $1 WHERE "userdemo"."id" = $2',
+        'UPDATE "userdemo" SET name = $1 WHERE "userdemo"."id" = $2',
         ["John", 1],
     )
 
@@ -355,7 +364,7 @@ def test_and_group():
         )
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" WHERE ("userdemo"."name" = "userdemo"."email" AND "userdemo"."id" > $1)',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" WHERE ("userdemo"."name" = "userdemo"."email" AND "userdemo"."id" > $1)',
         [0],
     )
 
@@ -372,7 +381,7 @@ def test_or_group():
         )
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" WHERE ("userdemo"."name" = "userdemo"."email" OR "userdemo"."id" > $1)',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" WHERE ("userdemo"."name" = "userdemo"."email" OR "userdemo"."id" > $1)',
         [0],
     )
 
@@ -392,7 +401,7 @@ def test_nested_and_or_group():
         )
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" FROM "userdemo" WHERE (("userdemo"."name" = "userdemo"."email" OR "userdemo"."id" > $1) AND "userdemo"."id" < $2)',
+        'SELECT "userdemo"."id" AS "userdemo_id" FROM "userdemo" WHERE (("userdemo"."name" = "userdemo"."email" OR "userdemo"."id" > $1) AND "userdemo"."id" < $2)',
         [0, 10],
     )
 
@@ -433,7 +442,7 @@ def test_distinct_on():
         .distinct_on(UserDemo.name)
     )
     assert new_query.build() == (
-        'SELECT DISTINCT ON ("userdemo"."name") "userdemo"."name", "userdemo"."email" FROM "userdemo"',
+        'SELECT DISTINCT ON ("userdemo"."name") "userdemo"."name" AS "userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo"',
         [],
     )
 
@@ -445,7 +454,7 @@ def test_distinct_on_multiple_fields():
         .distinct_on(UserDemo.name, UserDemo.email)
     )
     assert new_query.build() == (
-        'SELECT DISTINCT ON ("userdemo"."name", "userdemo"."email") "userdemo"."name", "userdemo"."email" FROM "userdemo"',
+        'SELECT DISTINCT ON ("userdemo"."name", "userdemo"."email") "userdemo"."name" AS "userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo"',
         [],
     )
 
@@ -509,12 +518,10 @@ def test_for_update_multiple_of():
         .for_update(of=(ArtifactDemo,))
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
-        '"userdemo_name", "userdemo"."email" as "userdemo_email", '
-        '"artifactdemo"."id" as "artifactdemo_id", "artifactdemo"."title" as '
-        '"artifactdemo_title", "artifactdemo"."user_id" as "artifactdemo_user_id" '
-        'FROM "userdemo" INNER JOIN artifactdemo ON "userdemo"."id" = "artifactdemo"."user_id" '
-        "FOR UPDATE OF artifactdemo, userdemo",
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS "userdemo_name", "userdemo"."email" AS "userdemo_email", '
+        '"artifactdemo"."id" AS "artifactdemo_id", "artifactdemo"."title" AS "artifactdemo_title", "artifactdemo"."user_id" AS "artifactdemo_user_id" '
+        'FROM "userdemo" INNER JOIN "artifactdemo" ON "userdemo"."id" = "artifactdemo"."user_id" '
+        'FOR UPDATE OF "artifactdemo", "userdemo"',
         [],
     )
 

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -17,8 +17,8 @@ class UserStatus(StrEnum):
 def test_select():
     new_query = QueryBuilder().select(UserDemo)
     assert new_query.build() == (
-        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
-        '"userdemo_name", "userdemo"."email" as "userdemo_email" FROM "userdemo"',
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS '
+        '"userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo"',
         [],
     )
 
@@ -408,8 +408,8 @@ def test_nested_and_or_group():
 
 #
 # Typehinting
-# These checks are run as part of the static typechecking we do
-# for our codebase, not as part of the pytest runtime.
+# These checks are run AS part of the static typechecking we do
+# for our codebase, not AS part of the pytest runtime.
 #
 
 
@@ -462,8 +462,8 @@ def test_distinct_on_multiple_fields():
 def test_for_update_basic():
     new_query = QueryBuilder().select(UserDemo).for_update()
     assert new_query.build() == (
-        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
-        '"userdemo_name", "userdemo"."email" as "userdemo_email" FROM "userdemo" FOR UPDATE',
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS '
+        '"userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo" FOR UPDATE',
         [],
     )
 
@@ -471,8 +471,8 @@ def test_for_update_basic():
 def test_for_update_nowait():
     new_query = QueryBuilder().select(UserDemo).for_update(nowait=True)
     assert new_query.build() == (
-        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
-        '"userdemo_name", "userdemo"."email" as "userdemo_email" FROM "userdemo" FOR UPDATE NOWAIT',
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS '
+        '"userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo" FOR UPDATE NOWAIT',
         [],
     )
 
@@ -480,8 +480,8 @@ def test_for_update_nowait():
 def test_for_update_skip_locked():
     new_query = QueryBuilder().select(UserDemo).for_update(skip_locked=True)
     assert new_query.build() == (
-        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
-        '"userdemo_name", "userdemo"."email" as "userdemo_email" FROM "userdemo" FOR UPDATE SKIP LOCKED',
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS '
+        '"userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo" FOR UPDATE SKIP LOCKED',
         [],
     )
 
@@ -489,8 +489,8 @@ def test_for_update_skip_locked():
 def test_for_update_of():
     new_query = QueryBuilder().select(UserDemo).for_update(of=(UserDemo,))
     assert new_query.build() == (
-        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
-        '"userdemo_name", "userdemo"."email" as "userdemo_email" FROM "userdemo" FOR UPDATE OF userdemo',
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS '
+        '"userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo" FOR UPDATE OF "userdemo"',
         [],
     )
 
@@ -503,8 +503,8 @@ def test_for_update_multiple_calls():
         .for_update(nowait=True)
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" as "userdemo_id", "userdemo"."name" as '
-        '"userdemo_name", "userdemo"."email" as "userdemo_email" FROM "userdemo" FOR UPDATE OF userdemo NOWAIT',
+        'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS '
+        '"userdemo_name", "userdemo"."email" AS "userdemo_email" FROM "userdemo" FOR UPDATE OF "userdemo" NOWAIT',
         [],
     )
 

--- a/iceaxe/__tests__/test_queries_str.py
+++ b/iceaxe/__tests__/test_queries_str.py
@@ -63,6 +63,71 @@ def test_query_element_hashable():
     assert hash(lit1) == hash(lit2)
 
 
+def test_query_element_sortable():
+    """Test that QueryElementBase subclasses can be sorted."""
+    # Test sorting of identifiers
+    identifiers = [
+        QueryIdentifier("users"),
+        QueryIdentifier("posts"),
+        QueryIdentifier("comments"),
+    ]
+    sorted_identifiers = sorted(identifiers)
+    assert [str(literal) for literal in sorted_identifiers] == [
+        '"comments"',
+        '"posts"',
+        '"users"',
+    ]
+
+    # Test sorting of literals
+    literals = [
+        QueryLiteral("SUM(*)"),
+        QueryLiteral("COUNT(*)"),
+        QueryLiteral("AVG(*)"),
+    ]
+    sorted_literals = sorted(literals)
+    assert [str(literal) for literal in sorted_literals] == [
+        "AVG(*)",
+        "COUNT(*)",
+        "SUM(*)",
+    ]
+
+    # Test sorting mixed elements
+    mixed = [
+        QueryIdentifier("users"),
+        QueryLiteral("COUNT(*)"),
+        QueryIdentifier("posts"),
+    ]
+    sorted_mixed = sorted(mixed)
+    assert [str(literal) for literal in sorted_mixed] == [
+        '"posts"',
+        '"users"',
+        "COUNT(*)",
+    ]
+
+    # Test sorting with duplicates
+    with_duplicates = [
+        QueryIdentifier("users"),
+        QueryIdentifier("posts"),
+        QueryIdentifier("users"),
+        QueryIdentifier("comments"),
+    ]
+    sorted_with_duplicates = sorted(with_duplicates)
+    assert [str(literal) for literal in sorted_with_duplicates] == [
+        '"comments"',
+        '"posts"',
+        '"users"',
+        '"users"',
+    ]
+
+    # Test reverse sorting
+    reverse_sorted = sorted(identifiers, reverse=True)
+    assert [str(literal) for literal in reverse_sorted] == [
+        '"users"',
+        '"posts"',
+        '"comments"',
+    ]
+
+
 def test_sql_call_column():
     """Test SQLGenerator's __call__ method with a column."""
     result = sql(TestModel.field_one)
@@ -89,8 +154,8 @@ def test_sql_select_table():
     result = sql.select(TestModel)
     assert isinstance(result, QueryLiteral)
     assert str(result) == (
-        '"testmodel"."field_one" as "testmodel_field_one", '
-        '"testmodel"."field_two" as "testmodel_field_two"'
+        '"testmodel"."field_one" AS "testmodel_field_one", '
+        '"testmodel"."field_two" AS "testmodel_field_two"'
     )
 
 

--- a/iceaxe/__tests__/test_queries_str.py
+++ b/iceaxe/__tests__/test_queries_str.py
@@ -1,0 +1,108 @@
+from iceaxe.base import TableBase
+from iceaxe.queries_str import QueryIdentifier, QueryLiteral, sql
+
+
+class TestModel(TableBase):
+    field_one: str
+    field_two: int
+
+
+def test_query_identifier():
+    """Test the QueryIdentifier class for proper SQL identifier quoting."""
+    identifier = QueryIdentifier("test_field")
+    assert str(identifier) == '"test_field"'
+
+    # Test with special characters and SQL keywords
+    identifier = QueryIdentifier("group")
+    assert str(identifier) == '"group"'
+
+    identifier = QueryIdentifier("test.field")
+    assert str(identifier) == '"test.field"'
+
+
+def test_query_literal():
+    """Test the QueryLiteral class for raw SQL inclusion."""
+    literal = QueryLiteral("COUNT(*)")
+    assert str(literal) == "COUNT(*)"
+
+    literal = QueryLiteral("CASE WHEN x > 0 THEN 1 ELSE 0 END")
+    assert str(literal) == "CASE WHEN x > 0 THEN 1 ELSE 0 END"
+
+
+def test_query_element_hashable():
+    """Test that QueryElementBase subclasses are hashable and work in sets/dicts."""
+    # Test set behavior
+    elements = {
+        QueryIdentifier("users"),
+        QueryIdentifier("users"),  # Duplicate should be removed
+        QueryIdentifier("posts"),
+        QueryLiteral("COUNT(*)"),
+        QueryLiteral("COUNT(*)"),  # Duplicate should be removed
+    }
+    assert len(elements) == 3
+    assert QueryIdentifier("users") in elements
+    assert QueryLiteral("COUNT(*)") in elements
+
+    # Test dictionary behavior
+    element_map = {
+        QueryIdentifier("users"): "users table",
+        QueryLiteral("COUNT(*)"): "count function",
+    }
+    assert element_map[QueryIdentifier("users")] == "users table"
+    assert element_map[QueryLiteral("COUNT(*)")] == "count function"
+
+    # Test hash consistency with equality
+    id1 = QueryIdentifier("test")
+    id2 = QueryIdentifier("test")
+    assert id1 == id2
+    assert hash(id1) == hash(id2)
+
+    lit1 = QueryLiteral("COUNT(*)")
+    lit2 = QueryLiteral("COUNT(*)")
+    assert lit1 == lit2
+    assert hash(lit1) == hash(lit2)
+
+
+def test_sql_call_column():
+    """Test SQLGenerator's __call__ method with a column."""
+    result = sql(TestModel.field_one)
+    assert isinstance(result, QueryLiteral)
+    assert str(result) == '"testmodel"."field_one"'
+
+
+def test_sql_call_table():
+    """Test SQLGenerator's __call__ method with a table."""
+    result = sql(TestModel)
+    assert isinstance(result, QueryIdentifier)
+    assert str(result) == '"testmodel"'
+
+
+def test_sql_select_column():
+    """Test SQLGenerator's select method with a column."""
+    result = sql.select(TestModel.field_one)
+    assert isinstance(result, QueryLiteral)
+    assert str(result) == '"testmodel"."field_one" AS "testmodel_field_one"'
+
+
+def test_sql_select_table():
+    """Test SQLGenerator's select method with a table."""
+    result = sql.select(TestModel)
+    assert isinstance(result, QueryLiteral)
+    assert str(result) == (
+        '"testmodel"."field_one" as "testmodel_field_one", '
+        '"testmodel"."field_two" as "testmodel_field_two"'
+    )
+
+
+def test_sql_raw_column():
+    """Test SQLGenerator's raw method with a column."""
+    result = sql.raw(TestModel.field_one)
+    assert isinstance(result, QueryIdentifier)
+    assert str(result) == '"field_one"'
+
+
+def test_sql_raw_table():
+    """Test SQLGenerator's raw method with a table."""
+    result = sql.raw(TestModel)
+    assert isinstance(result, QueryIdentifier)
+    assert str(result) == '"testmodel"'

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -11,7 +11,6 @@ from pydantic.main import _model_construction
 from pydantic_core import PydanticUndefined
 
 from iceaxe.field import DBFieldClassDefinition, DBFieldInfo, Field
-from iceaxe.queries_str import QueryIdentifier, QueryLiteral
 
 
 @dataclass_transform(kw_only_default=True, field_specifiers=(PydanticField,))
@@ -310,26 +309,3 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
             for field, info in cls.model_fields.items()
             if field not in INTERNAL_TABLE_FIELDS
         }
-
-    @classmethod
-    def select_fields(cls) -> QueryLiteral:
-        """
-        Generate a SQL-safe string for selecting all fields from this table.
-        The output format is "{table_name}.{field_name} as {table_name}_{field_name}"
-        for each field, which ensures proper field name resolution in complex queries.
-
-        :return: SQL-safe field selection string
-
-        ```python {{sticky: True}}
-        # For a User class with fields 'id' and 'name':
-        User.select_fields()
-        # Returns: '"users"."id" as "users_id", "users"."name" as "users_name"'
-        ```
-        """
-        table_token = QueryIdentifier(cls.get_table_name())
-        select_fields: list[str] = []
-        for field_name in cls.get_client_fields():
-            field_token = QueryIdentifier(field_name)
-            return_field = QueryIdentifier(f"{cls.get_table_name()}_{field_name}")
-            select_fields.append(f"{table_token}.{field_token} as {return_field}")
-        return QueryLiteral(", ".join(select_fields))

--- a/iceaxe/field.py
+++ b/iceaxe/field.py
@@ -202,6 +202,12 @@ T = TypeVar("T")
 
 
 class DBFieldClassDefinition(Generic[T], ComparisonBase[T]):
+    """
+    The returned model when users access a field directly from
+    the table class, e.g. `User.id`
+
+    """
+
     root_model: Type["TableBase"]
     key: str
     field_definition: DBFieldInfo

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -1006,7 +1006,9 @@ class QueryBuilder(Generic[P, QueryType]):
                     variables.append(having_condition.right)
                     having_value = QueryLiteral("$" + str(len(variables)))
 
-                query += f"{having_field} {having_condition.comparison.value} {having_value}"
+                query += (
+                    f"{having_field} {having_condition.comparison.value} {having_value}"
+                )
 
         if self._order_by_clauses:
             query += " ORDER BY " + ", ".join(self._order_by_clauses)

--- a/iceaxe/queries_str.py
+++ b/iceaxe/queries_str.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from iceaxe.typing import is_base_table, is_column
+
 
 class QueryElementBase(ABC):
     """
@@ -9,13 +11,27 @@ class QueryElementBase(ABC):
     This class provides the foundation for handling different types of SQL elements
     (like identifiers and literals) with their specific escaping and formatting rules.
 
-    The class implements equality comparisons based on the processed string representation,
-    making it suitable for comparing query elements in test assertions and caching.
+    The class implements equality comparisons and hashing based on the processed string
+    representation, making it suitable for comparing query elements in test assertions,
+    caching, and using elements as dictionary keys or in sets.
 
     ```python {{sticky: True}}
     # Base class is not used directly, but through its subclasses:
     table_name = QueryIdentifier("users")  # -> "users"
     raw_sql = QueryLiteral("COUNT(*)")    # -> COUNT(*)
+
+    # Can be used in sets and as dictionary keys
+    unique_elements = {
+        QueryIdentifier("users"),
+        QueryIdentifier("users"),  # Duplicate will be removed
+        QueryIdentifier("posts")
+    }
+    assert len(unique_elements) == 2
+
+    element_map = {
+        QueryIdentifier("users"): "users table",
+        QueryLiteral("COUNT(*)"): "count function"
+    }
     ```
     """
 
@@ -47,6 +63,15 @@ class QueryElementBase(ABC):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self._value})"
+
+    def __hash__(self):
+        """
+        Generate a hash based on the string representation of the query element.
+        This makes QueryElementBase instances usable as dictionary keys and in sets.
+
+        :return: Hash value of the processed string
+        """
+        return hash(str(self))
 
 
 class QueryIdentifier(QueryElementBase):
@@ -101,3 +126,172 @@ class QueryLiteral(QueryElementBase):
 
     def process_value(self, value: str):
         return value
+
+
+class SQLGenerator:
+    """
+    The SQLGenerator class provides a convenient way to generate SQL-safe strings for various
+    query elements. It acts as a singleton that handles the proper formatting and escaping
+    of table names, column names, and other SQL elements.
+
+    The class provides three main methods:
+    - __call__: For generating table-qualified column names
+    - select: For generating SELECT clause elements with proper aliases
+    - raw: For generating raw identifiers without table qualification
+
+    Each method handles both column and table inputs, applying appropriate formatting rules
+    to prevent SQL injection and ensure proper identifier quoting.
+
+    ```python {{sticky: True}}
+    # Basic usage with columns
+    sql(User.name)          # -> "users"."name"
+    sql.select(User.name)   # -> "users"."name" AS "users_name"
+    sql.raw(User.name)      # -> "name"
+
+    # Basic usage with tables
+    sql(User)               # -> "users"
+    sql.select(User)        # -> "users"."id" as "users_id", "users"."name" as "users_name"
+    sql.raw(User)          # -> "users"
+
+    # Usage in query building
+    query = f"SELECT {sql.select(User.name)} FROM {sql(User)}"
+    # -> SELECT "users"."name" AS "users_name" FROM "users"
+    ```
+    """
+
+    def __call__(self, obj) -> QueryElementBase:
+        """
+        Generate a table-qualified column name or table identifier. This is the default
+        format used in most SQL contexts where a column or table reference is needed.
+
+        For columns, the output includes the table name to prevent ambiguity in JOINs
+        and complex queries. For tables, it returns just the quoted table name.
+
+        :param obj: A column or table object
+        :return: A SQL-safe string representation
+
+        ```python {{sticky: True}}
+        # Column usage
+        sql(User.name)
+        # -> "users"."name"
+
+        sql(Post.title)
+        # -> "posts"."title"
+
+        # Table usage
+        sql(User)
+        # -> "users"
+
+        # In a query context
+        query = f"UPDATE {sql(User)} SET {sql(User.name)} = 'John'"
+        # -> UPDATE "users" SET "users"."name" = 'John'
+
+        # In a JOIN context
+        query = f"SELECT {sql(User.name)} FROM {sql(User)} JOIN {sql(Post)} ON {sql(User.id)} = {sql(Post.user_id)}"
+        # -> SELECT "users"."name" FROM "users" JOIN "posts" ON "users"."id" = "posts"."user_id"
+        ```
+        """
+        if is_column(obj):
+            table = QueryIdentifier(obj.root_model.get_table_name())
+            column = QueryIdentifier(obj.key)
+            return QueryLiteral(f"{table}.{column}")
+        elif is_base_table(obj):
+            return QueryIdentifier(obj.get_table_name())
+        else:
+            raise ValueError(f"Invalid type for sql: {type(obj)}")
+
+    def select(self, obj) -> QueryElementBase:
+        """
+        Generate a SQL-safe string for selecting fields with proper aliases. This format
+        is specifically designed for SELECT clauses where unique column aliases are needed
+        to prevent name collisions.
+
+        For columns, generates a table-qualified column with an alias that includes both
+        table and column names. For tables, generates a comma-separated list of all
+        columns with their aliases.
+
+        :param obj: A column or table object
+        :return: A SQL-safe string with proper SELECT clause formatting
+
+        ```python {{sticky: True}}
+        # Single column selection
+        sql.select(User.name)
+        # -> "users"."name" AS "users_name"
+
+        # Full table selection
+        sql.select(User)
+        # -> "users"."id" as "users_id", "users"."name" as "users_name", "users"."email" as "users_email"
+
+        # In a complex query with multiple tables
+        query = f'''
+            SELECT
+                {sql.select(User)},
+                {sql.select(Post.title)}
+            FROM {sql(User)}
+            JOIN {sql(Post)} ON {sql(User.id)} = {sql(Post.user_id)}
+        '''
+        # -> SELECT
+        #    "users"."id" as "users_id", "users"."name" as "users_name",
+        #    "posts"."title" AS "posts_title"
+        #    FROM "users"
+        #    JOIN "posts" ON "users"."id" = "posts"."user_id"
+        ```
+        """
+        if is_column(obj):
+            table = QueryIdentifier(obj.root_model.get_table_name())
+            column = QueryIdentifier(obj.key)
+            alias = QueryIdentifier(f"{obj.root_model.get_table_name()}_{obj.key}")
+            return QueryLiteral(f"{table}.{column} AS {alias}")
+        elif is_base_table(obj):
+            table_token = QueryIdentifier(obj.get_table_name())
+            select_fields: list[str] = []
+            for field_name in obj.get_client_fields():
+                field_token = QueryIdentifier(field_name)
+                return_field = QueryIdentifier(f"{obj.get_table_name()}_{field_name}")
+                select_fields.append(f"{table_token}.{field_token} as {return_field}")
+            return QueryLiteral(", ".join(select_fields))
+        else:
+            raise ValueError(f"Invalid type for select: {type(obj)}")
+
+    def raw(self, obj) -> QueryElementBase:
+        """
+        Generate a raw identifier without table qualification. This is useful in specific
+        contexts where you need just the column or table name without any additional
+        qualification.
+
+        For columns, returns just the column name without the table prefix. For tables,
+        returns just the table name. All identifiers are still properly quoted.
+
+        :param obj: A column or table object
+        :return: A SQL-safe raw identifier
+
+        ```python {{sticky: True}}
+        # Column usage
+        sql.raw(User.name)
+        # -> "name"
+
+        sql.raw(Post.title)
+        # -> "title"
+
+        # Table usage
+        sql.raw(User)
+        # -> "users"
+
+        # Useful in specific contexts like ORDER BY or GROUP BY
+        query = f"SELECT {sql.select(User.name)} FROM {sql(User)} ORDER BY {sql.raw(User.name)}"
+        # -> SELECT "users"."name" AS "users_name" FROM "users" ORDER BY "name"
+
+        # Or in UPDATE SET clauses where table qualification isn't needed
+        query = f"UPDATE {sql(User)} SET {sql.raw(User.name)} = 'John'"
+        # -> UPDATE "users" SET "name" = 'John'
+        ```
+        """
+        if is_column(obj):
+            return QueryIdentifier(obj.key)
+        elif is_base_table(obj):
+            return QueryIdentifier(obj.get_table_name())
+        else:
+            raise ValueError(f"Invalid type for raw: {type(obj)}")
+
+
+sql = SQLGenerator()

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -383,7 +383,8 @@ class DatabaseHandler:
                 )
             else:
                 raise ValueError(
-                    f"JSON fields must have Field(is_json=True) specified: {annotation}"
+                    f"JSON fields must have Field(is_json=True) specified: {annotation}\n"
+                    f"Column: {table.__name__}.{key}"
                 )
 
         raise ValueError(f"Unsupported column type: {annotation}")

--- a/iceaxe/session.py
+++ b/iceaxe/session.py
@@ -18,11 +18,11 @@ from iceaxe.base import TableBase
 from iceaxe.logging import LOGGER
 from iceaxe.queries import (
     QueryBuilder,
-    QueryIdentifier,
     is_base_table,
     is_column,
     is_function_metadata,
 )
+from iceaxe.queries_str import QueryIdentifier
 from iceaxe.session_optimized import optimize_exec_casting
 
 P = ParamSpec("P")
@@ -163,7 +163,13 @@ class DBConnection:
         """
         sql_text, variables = query.build()
         LOGGER.debug(f"Executing query: {sql_text} with variables: {variables}")
-        values = await self.conn.fetch(sql_text, *variables)
+        try:
+            values = await self.conn.fetch(sql_text, *variables)
+        except Exception as e:
+            LOGGER.error(
+                f"Error executing query: {sql_text} with variables: {variables}"
+            )
+            raise e
 
         if query._query_type == "SELECT":
             # Pre-cache the select types for better performance

--- a/iceaxe/session_optimized.pyx
+++ b/iceaxe/session_optimized.pyx
@@ -145,9 +145,12 @@ cdef list process_values(
 
                 elif raw_is_column:
                     try:
-                        item = value[select_raw.key]
+                        # Use the table-qualified column name
+                        table_name = select_raw.root_model.get_table_name()
+                        column_name = select_raw.key
+                        item = value[f"{table_name}_{column_name}"]
                     except KeyError:
-                        raise KeyError(f"Key '{select_raw.key}' not found in value.")
+                        raise KeyError(f"Key '{table_name}_{column_name}' not found in value.")
                     result_value[j] = <PyObject*>item
                     Py_INCREF(item)
 


### PR DESCRIPTION
Our query builder supports raw string execution if users are writing SQL commands that are too complex for our standard ORM queries. Previously users would have to keep their raw strings in sync with database definitions - and if a column/table name changed along the way their logic would break silently without any linting warnings.

This PR exposes a more reliable approach to sql generation:

```
from iceaxe import sql

query = select(MyModel).text(
f"""
SELECT {sql.select(MyModel)}
FROM {sql(MyModel)}
WHERE {sql(MyModel.name)} == $1
""",
"John"
)
```

These will automatically resolve to the proper sql strings. The `SELECT` in this case will fetch all fields with correct aliases, then return a standard list of MyModel instances. The `WHERE` will also filter for the correct fields with table/column convention.