### PR TITLE
Add alias support in typehinted queries

### DIFF
--- a/iceaxe/alias.py
+++ b/iceaxe/alias.py
@@ -1,0 +1,56 @@
+from typing import Generic, TypeVar, cast
+
+T = TypeVar("T")
+
+
+class Alias(Generic[T]):
+    def __init__(self, name: str, type: T):
+        self.name = name
+        self.type = type
+
+    def __str__(self):
+        return self.name
+
+
+def alias(name: str, type: T) -> T:
+    """
+    Creates an alias for a field in raw SQL queries, allowing for type-safe mapping of raw SQL results.
+    This is particularly useful when you need to combine ORM-based queries with raw SQL, while maintaining
+    type safety and automatic deserialization.
+
+    ```python {{sticky: True}}
+    # Basic usage with a single alias
+    select(alias("name", int)).text(
+        "SELECT concat(first_name, ' ', last_name) AS name FROM users"
+    )
+
+    # Combining with ORM models
+    select((User, alias("total_orders", int))).text(
+        "SELECT users.*, COUNT(orders.id) AS total_orders FROM users LEFT JOIN orders ON users.id = orders.user_id GROUP BY users.id"
+    )
+
+    # Multiple aliases in a single query
+    select((
+        alias("full_name", str),
+        alias("order_count", int),
+        alias("total_spent", float)
+    )).text(
+        '''
+        SELECT
+            concat(first_name, ' ', last_name) AS full_name,
+            COUNT(orders.id) AS order_count,
+            SUM(orders.amount) AS total_spent
+        FROM users
+        LEFT JOIN orders ON users.id = orders.user_id
+        GROUP BY users.id
+        '''
+    )
+    ```
+
+    :param name: The name of the alias as it appears in the SQL query's AS clause
+    :param type: The Python type to cast the result to (e.g., int, str, float). This should
+        mirror the type of the field in the raw SQL query.
+    :return: A type-safe alias that can be used in select() statements
+
+    """
+    return cast(T, Alias(name, type))

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -13,6 +13,7 @@ from typing import (
 from uuid import UUID
 
 if TYPE_CHECKING:
+    from iceaxe.alias import Alias
     from iceaxe.base import (
         DBFieldClassDefinition,
         TableBase,
@@ -58,6 +59,12 @@ def is_function_metadata(obj: Any) -> TypeGuard[FunctionMetadata]:
     from iceaxe.functions import FunctionMetadata
 
     return isinstance(obj, FunctionMetadata)
+
+
+def is_alias(obj: Any) -> TypeGuard[Alias]:
+    from iceaxe.alias import Alias
+
+    return isinstance(obj, Alias)
 
 
 def column(obj: T) -> DBFieldClassDefinition[T]:


### PR DESCRIPTION
Even when using raw SQL queries with `select().text()`, users often want to cast the response values into native TableBase instances or raw field values. Previously we only supported TableBases or Field wrappers being passed into `select()` queries, so there was no way to retrieve a value that wasn't already defined in the python schema.

This PR adds support for specifying aliases within the initial select() query. This uses our standard postprocessing layer to convert from SQL value response columns into our native objects, but allows users to specify any query value that appears within the SQL text.