### PR TITLE
Warning on uncommitted modified models

### DIFF
--- a/iceaxe/__tests__/test_modifications.py
+++ b/iceaxe/__tests__/test_modifications.py
@@ -1,0 +1,126 @@
+import logging
+
+import pytest
+
+from iceaxe.__tests__.conf_models import ArtifactDemo, UserDemo
+from iceaxe.modifications import (
+    MODIFICATION_TRACKER_VERBOSITY,
+    Modification,
+    ModificationTracker,
+)
+
+
+@pytest.fixture
+def tracker():
+    """Create a fresh ModificationTracker for each test."""
+    return ModificationTracker()
+
+
+@pytest.fixture
+def demo_instance():
+    """Create a demo model instance for testing."""
+    return UserDemo(id=1, name="test", email="test@example.com")
+
+
+def test_get_current_stack_trace():
+    """Test that get_current_stack_trace returns both traces."""
+    full_trace, user_trace = Modification.get_current_stack_trace()
+
+    assert isinstance(full_trace, str)
+    assert isinstance(user_trace, str)
+    assert "test_modifications.py" in user_trace
+    assert len(full_trace) >= len(user_trace)
+
+
+def test_track_modification_new_instance(
+    tracker: ModificationTracker, demo_instance: UserDemo
+):
+    """Test tracking a new modification."""
+    tracker.track_modification(demo_instance)
+
+    instance_id = id(demo_instance)
+    assert instance_id in tracker.modified_models
+
+    modification = tracker.modified_models[instance_id]
+    assert modification.instance == demo_instance
+    assert "test_modifications.py" in modification.user_stack_trace
+
+
+def test_track_modification_duplicate(
+    tracker: ModificationTracker, demo_instance: UserDemo
+):
+    """Test that tracking the same instance twice only records it once."""
+    tracker.track_modification(demo_instance)
+    tracker.track_modification(demo_instance)
+
+    assert len(tracker.modified_models) == 1
+
+
+def test_clear_status_single(tracker: ModificationTracker, demo_instance: UserDemo):
+    """Test committing a single model."""
+    tracker.track_modification(demo_instance)
+    tracker.clear_status([demo_instance])
+
+    assert id(demo_instance) not in tracker.modified_models
+
+
+def test_clear_status_partial(tracker: ModificationTracker):
+    """Test committing some but not all models."""
+    instance1 = UserDemo(id=1, name="test1", email="test1@example.com")
+    instance2 = UserDemo(id=2, name="test2", email="test2@example.com")
+
+    tracker.track_modification(instance1)
+    tracker.track_modification(instance2)
+    tracker.clear_status([instance1])
+
+    assert id(instance1) not in tracker.modified_models
+    assert id(instance2) in tracker.modified_models
+    assert tracker.modified_models[id(instance2)].instance == instance2
+
+
+@pytest.mark.parametrize("verbosity", ["ERROR", "WARNING", "INFO", None])
+def test_log_with_different_verbosity(
+    tracker: ModificationTracker,
+    demo_instance: UserDemo,
+    verbosity: MODIFICATION_TRACKER_VERBOSITY,
+    caplog,
+):
+    """Test logging with different verbosity levels."""
+    tracker.verbosity = verbosity
+    tracker.track_modification(demo_instance)
+
+    with caplog.at_level(logging.INFO):
+        tracker.log()
+
+    if verbosity:
+        assert len(caplog.records) > 0
+        assert "Uncommitted object" in caplog.records[0].message
+        if verbosity == "INFO":
+            assert any(
+                "Full stack trace" in record.message for record in caplog.records
+            )
+    else:
+        assert len(caplog.records) == 0
+
+
+def test_multiple_model_types(tracker: ModificationTracker):
+    """Test tracking modifications for different model types."""
+    instance1 = UserDemo(id=1, name="test", email="test@example.com")
+    instance2 = ArtifactDemo(id=2, title="test", user_id=1)
+
+    tracker.track_modification(instance1)
+    tracker.track_modification(instance2)
+
+    assert len(tracker.modified_models) == 2
+    assert id(instance1) in tracker.modified_models
+    assert id(instance2) in tracker.modified_models
+
+
+def test_clear_status_cleanup(tracker: ModificationTracker):
+    """Test that clear_status properly cleans up empty model lists."""
+    instance = UserDemo(id=1, name="test", email="test@example.com")
+    tracker.track_modification(instance)
+
+    assert id(instance) in tracker.modified_models
+    tracker.clear_status([instance])
+    assert id(instance) not in tracker.modified_models

--- a/iceaxe/__tests__/test_modifications.py
+++ b/iceaxe/__tests__/test_modifications.py
@@ -94,7 +94,7 @@ def test_log_with_different_verbosity(
 
     if verbosity:
         assert len(caplog.records) > 0
-        assert "Uncommitted object" in caplog.records[0].message
+        assert "Object modified locally but not committed" in caplog.records[0].message
         if verbosity == "INFO":
             assert any(
                 "Full stack trace" in record.message for record in caplog.records

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -326,3 +326,25 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         Register a callback to be called when the model is modified.
         """
         self.modified_attrs_callbacks.append(callback)
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Compare two model instances, ignoring modified_attrs_callbacks.
+        This ensures that two models with the same data but different callbacks are considered equal.
+        """
+        if not isinstance(other, self.__class__):
+            return False
+
+        # Get all fields except modified_attrs_callbacks
+        fields = {
+            field: value
+            for field, value in self.__dict__.items()
+            if field not in INTERNAL_TABLE_FIELDS
+        }
+        other_fields = {
+            field: value
+            for field, value in other.__dict__.items()
+            if field not in INTERNAL_TABLE_FIELDS
+        }
+
+        return fields == other_fields

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -253,12 +253,16 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
 
     # Private methods
     modified_attrs: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    """
+    Dictionary of modified field values since instantiation or the last clear_modified_attributes() call.
+    Used to construct differential update queries.
+    """
+
     modified_attrs_callbacks: list[Callable[[Self], None]] = Field(
         default_factory=list, exclude=True
     )
     """
-    Dictionary of modified field values since instantiation or the last clear_modified_attributes() call.
-    Used to construct differential update queries.
+    List of callbacks to be called when the model is modified.
     """
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -317,9 +321,8 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
             if field not in INTERNAL_TABLE_FIELDS
         }
 
-    @classmethod
-    def register_modified_callback(cls, callback: Callable[[Self], None]) -> None:
+    def register_modified_callback(self, callback: Callable[[Self], None]) -> None:
         """
         Register a callback to be called when the model is modified.
         """
-        cls.modified_attrs_callbacks.append(callback)
+        self.modified_attrs_callbacks.append(callback)

--- a/iceaxe/comparison.py
+++ b/iceaxe/comparison.py
@@ -198,11 +198,11 @@ class FieldComparison(Generic[T]):
             elif self.comparison in (ComparisonType.IN, ComparisonType.NOT_IN):
                 variables.append(self.right)
                 comparison_map = {
-                    ComparisonType.IN: ComparisonType.EQ,
-                    ComparisonType.NOT_IN: ComparisonType.NE,
+                    ComparisonType.IN: (ComparisonType.EQ, "ANY"),
+                    ComparisonType.NOT_IN: (ComparisonType.NE, "ALL"),
                 }
-                comparison = comparison_map[self.comparison]
-                value = QueryLiteral(f"ANY(${variable_offset})")
+                comparison, operator = comparison_map[self.comparison]
+                value = QueryLiteral(f"{operator}(${variable_offset})")
             else:
                 # Support comparison to static values
                 variables.append(self.right)

--- a/iceaxe/modifications.py
+++ b/iceaxe/modifications.py
@@ -167,7 +167,9 @@ class ModificationTracker:
         log_level = getattr(logging, self.verbosity)
 
         for mod in self.modified_models.values():
-            LOGGER.log(log_level, f"Uncommitted object: {mod.instance}")
+            LOGGER.log(
+                log_level, f"Object modified locally but not committed: {mod.instance}"
+            )
             LOGGER.log(log_level, f"Modified at:\n{mod.user_stack_trace}")
             if self.verbosity == "INFO":
                 LOGGER.log(log_level, f"Full stack trace:\n{mod.stack_trace}")

--- a/iceaxe/modifications.py
+++ b/iceaxe/modifications.py
@@ -1,0 +1,155 @@
+import logging
+import traceback
+from dataclasses import dataclass
+from typing import Literal, Sequence, TypeVar
+
+from iceaxe.base import TableBase
+
+LOGGER = logging.getLogger(__name__)
+MODIFICATION_TRACKER_VERBOSITY = Literal["ERROR", "WARNING", "INFO"] | None
+T = TypeVar("T", bound=TableBase)
+
+
+@dataclass
+class Modification:
+    """
+    Tracks a single modification to a database model instance, including stack trace information.
+
+    This class stores both the full stack trace and a simplified user-specific stack trace
+    that excludes library code. This helps with debugging by showing where in the user's
+    code a modification was made.
+
+    :param instance: The model instance that was modified
+    :param stack_trace: The complete stack trace at the time of modification
+    :param user_stack_trace: The most relevant user code stack trace, excluding library code
+    """
+
+    instance: TableBase
+
+    # The full stack trace of the modification.
+    stack_trace: str
+
+    # Most specific line of the stack trace that is part of the user's code.
+    user_stack_trace: str
+
+    @staticmethod
+    def get_current_stack_trace() -> tuple[str, str]:
+        """
+        Get both the full stack trace and the most specific user code stack trace.
+
+        The user stack trace filters out library code and frozen code to focus on
+        the most relevant user code location where a modification occurred.
+
+        :return: A tuple containing (full_stack_trace, user_stack_trace)
+        :rtype: tuple[str, str]
+        """
+        stack = traceback.extract_stack()[:-1]  # Remove the current frame
+        full_trace = "".join(traceback.format_list(stack))
+
+        # Find the most specific user code stack trace by filtering out library code
+        user_traces = [
+            frame
+            for frame in stack
+            if "site-packages" not in frame.filename
+            and "<frozen" not in frame.filename
+            and "iceaxe/modifications.py" not in frame.filename
+        ]
+        user_trace = ""
+        if user_traces:
+            user_trace = "".join(traceback.format_list([user_traces[-1]]))
+
+        return full_trace, user_trace
+
+
+class ModificationTracker:
+    """
+    Tracks modifications to database model instances and manages their lifecycle.
+
+    This class maintains a record of all modified model instances that haven't been
+    committed yet. It provides functionality to track new modifications, handle commits,
+    and log any remaining uncommitted modifications.
+
+    The tracker organizes modifications by model class and prevents duplicate tracking
+    of the same instance. It also captures stack traces at the point of modification
+    to help with debugging.
+    """
+
+    modified_models: dict[int, Modification]
+    """
+    Dictionary mapping model classes to lists of their modifications
+    """
+
+    verbosity: MODIFICATION_TRACKER_VERBOSITY | None
+    """
+    The logging level to use when reporting uncommitted modifications
+    """
+
+    def __init__(self, verbosity: MODIFICATION_TRACKER_VERBOSITY | None = None):
+        """
+        Initialize a new ModificationTracker.
+
+        Creates an empty modification tracking dictionary and sets the initial
+        verbosity level to None.
+        """
+        self.modified_models = {}
+        self.verbosity = verbosity
+
+    def track_modification(self, instance: TableBase) -> None:
+        """
+        Track a modification to a model instance along with its stack trace.
+
+        This method records a modification to a model instance if it hasn't already
+        been tracked. It captures both the full stack trace and a user-specific
+        stack trace at the point of modification.
+
+        :param instance: The model instance that was modified
+        :type instance: TableBase
+        """
+        # Get stack traces
+        full_trace, user_trace = Modification.get_current_stack_trace()
+
+        # Only track if we haven't already tracked this instance
+        instance_id = id(instance)
+        if instance_id not in self.modified_models:
+            modification = Modification(
+                instance=instance, stack_trace=full_trace, user_stack_trace=user_trace
+            )
+            self.modified_models[instance_id] = modification
+
+    def clear_status(self, models: Sequence[TableBase]) -> None:
+        """
+        Remove models that are about to be committed from tracking.
+
+        This method should be called before committing changes to the database.
+        It removes the specified models from tracking since they will no longer
+        be in an uncommitted state.
+
+        :param models: List of model instances that will be committed
+        :type models: list[TableBase]
+        """
+        for instance in models:
+            instance_id = id(instance)
+            if instance_id in self.modified_models:
+                del self.modified_models[instance_id]
+
+    def log(self) -> None:
+        """
+        Log all uncommitted modifications with their stack traces.
+
+        This method logs information about all tracked modifications that haven't
+        been committed yet. The logging level is determined by the tracker's
+        verbosity setting. At the INFO level, it includes the full stack trace
+        in addition to the user stack trace.
+
+        If verbosity is not set (None), this method does nothing.
+        """
+        if not self.verbosity:
+            return
+
+        log_level = getattr(logging, self.verbosity)
+
+        for mod in self.modified_models.values():
+            LOGGER.log(log_level, f"Uncommitted object: {mod.instance}")
+            LOGGER.log(log_level, f"Modified at:\n{mod.user_stack_trace}")
+            if self.verbosity == "INFO":
+                LOGGER.log(log_level, f"Full stack trace:\n{mod.stack_trace}")

--- a/iceaxe/mountaineer/dependencies/core.py
+++ b/iceaxe/mountaineer/dependencies/core.py
@@ -53,7 +53,8 @@ async def get_db_connection(
         password=config.POSTGRES_PASSWORD,
         database=config.POSTGRES_DB,
     )
+    connection = DBConnection(conn)
     try:
-        yield DBConnection(conn)
+        yield connection
     finally:
-        await conn.close()
+        await connection.close()

--- a/iceaxe/session.py
+++ b/iceaxe/session.py
@@ -261,6 +261,9 @@ class DBConnection:
                         setattr(obj, primary_key, result[primary_key])
                     obj.clear_modified_attributes()
 
+        for obj in objects:
+            obj.register_modified_callback(self.modification_tracker.track_modification)
+
         self.modification_tracker.clear_status(objects)
 
     @overload

--- a/iceaxe/session.py
+++ b/iceaxe/session.py
@@ -16,6 +16,7 @@ from typing_extensions import TypeVarTuple
 
 from iceaxe.base import TableBase
 from iceaxe.logging import LOGGER
+from iceaxe.modifications import ModificationTracker
 from iceaxe.queries import (
     QueryBuilder,
     is_base_table,
@@ -77,15 +78,23 @@ class DBConnection:
     ```
     """
 
-    def __init__(self, conn: asyncpg.Connection):
+    def __init__(
+        self,
+        conn: asyncpg.Connection,
+        uncommitted_verbosity: Literal["ERROR", "WARNING", "INFO"] | None = None,
+    ):
         """
         Initialize a new database connection wrapper.
 
         :param conn: An asyncpg Connection instance to wrap
+        :param uncommitted_verbosity: The verbosity level if objects are modified but not committed when
+            the session is closed, defaults to nothing
+
         """
         self.conn = conn
         self.obj_to_primary_key: dict[str, str | None] = {}
         self.in_transaction = False
+        self.modification_tracker = ModificationTracker(uncommitted_verbosity)
 
     @asynccontextmanager
     async def transaction(self):
@@ -183,6 +192,18 @@ class DBConnection:
             ]
 
             result_all = optimize_exec_casting(values, query._select_raw, select_types)
+
+            # Only loop through results if we have verbosity enabled, since this logic otherwise
+            # is wasted if no content will eventually be logged
+            if self.modification_tracker.verbosity:
+                for row in result_all:
+                    elements = row if isinstance(row, tuple) else (row,)
+                    for element in elements:
+                        if isinstance(element, TableBase):
+                            element.register_modified_callback(
+                                self.modification_tracker.track_modification
+                            )
+
             return cast(list[T], result_all)
 
         return None
@@ -239,6 +260,8 @@ class DBConnection:
                     if primary_key and result:
                         setattr(obj, primary_key, result[primary_key])
                     obj.clear_modified_attributes()
+
+        self.modification_tracker.clear_status(objects)
 
     @overload
     async def upsert(
@@ -374,6 +397,8 @@ class DBConnection:
 
                     obj.clear_modified_attributes()
 
+        self.modification_tracker.clear_status(objects)
+
         return results if returning_fields_cols else None
 
     async def update(self, objects: Sequence[TableBase]):
@@ -430,6 +455,8 @@ class DBConnection:
                     await self.conn.execute(query, *values)
                     obj.clear_modified_attributes()
 
+        self.modification_tracker.clear_status(objects)
+
     async def delete(self, objects: Sequence[TableBase]):
         """
         Delete one or more model instances from the database.
@@ -464,6 +491,8 @@ class DBConnection:
                 for obj in model_objects:
                     query = f"DELETE FROM {table_name} WHERE {primary_key_name} = $1"
                     await self.conn.execute(query, getattr(obj, primary_key))
+
+        self.modification_tracker.clear_status(objects)
 
     async def refresh(self, objects: Sequence[TableBase]):
         """
@@ -518,6 +547,13 @@ class DBConnection:
                         f"Object {obj} with primary key {obj_id} not found in database"
                     )
 
+        # When an object is refreshed, it's fully overwritten with the new data so by
+        # definition it's no longer modified
+        for obj in objects:
+            obj.clear_modified_attributes()
+
+        self.modification_tracker.clear_status(objects)
+
     async def get(
         self, model: Type[TableType], primary_key_value: Any
     ) -> TableType | None:
@@ -559,6 +595,13 @@ class DBConnection:
         )
         results = await self.exec(query)
         return results[0] if results else None
+
+    async def close(self):
+        """
+        Close the database connection.
+        """
+        await self.conn.close()
+        self.modification_tracker.log()
 
     def _aggregate_models_by_table(self, objects: Sequence[TableBase]):
         """


### PR DESCRIPTION
Unlike some other ORMs, in-memory Iceaxe table instances are not inherently linked to the underlying session where they were created. As such we don't natively support a global `.commit()` that will flush all modified changes to the database. This is a core design choice to provide better portability of these data models and encourage explicitness in database interaction. However especially if you're porting over existing database code, it's possible some modifications snuck through the cracks and were saved in memory but not committed back to the database.

This PR adds support for a modification tracker, which is a new centralized class that owns central book-keeping of model modifications. If you create a `DBConnection` with non-null verbosity, we will track any un-inserted or un-updated models when the session is closed and log these out to the console as potential warnings to investigate.