### PR TITLE
Support function use in group by

### DIFF
--- a/iceaxe/__tests__/conf_models.py
+++ b/iceaxe/__tests__/conf_models.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pyinstrument import Profiler
 
-from iceaxe.base import Field, TableBase
+from iceaxe.base import Field, TableBase, UniqueConstraint
 
 
 class UserDemo(TableBase):
@@ -101,6 +101,19 @@ class DemoModelB(TableBase):
     name: str
     category: str
     code: str = Field(unique=True)
+
+
+class JsonDemo(TableBase):
+    """
+    Model for testing JSON field updates.
+    """
+
+    id: int | None = Field(primary_key=True, default=None)
+    settings: dict[Any, Any] = Field(is_json=True)
+    metadata: dict[Any, Any] | None = Field(is_json=True)
+    unique_val: str
+
+    table_args = [UniqueConstraint(columns=["unique_val"])]
 
 
 @contextmanager

--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -586,3 +586,20 @@ def test_multiple_group_by():
         'GROUP BY "employee"."department", "employee"."last_name"',
         [],
     )
+
+
+def test_group_by_with_function():
+    new_query = (
+        QueryBuilder()
+        .select(
+            (
+                func.date_trunc("month", FunctionDemoModel.created_at),
+                func.count(FunctionDemoModel.id),
+            )
+        )
+        .group_by(func.date_trunc("month", FunctionDemoModel.created_at))
+    )
+    assert new_query.build() == (
+        'SELECT date_trunc(\'month\', "functiondemomodel"."created_at") AS aggregate_0, count("functiondemomodel"."id") AS aggregate_1 FROM "functiondemomodel" GROUP BY date_trunc(\'month\', "functiondemomodel"."created_at")',
+        [],
+    )

--- a/iceaxe/mountaineer/config.py
+++ b/iceaxe/mountaineer/config.py
@@ -1,5 +1,7 @@
 from pydantic_settings import BaseSettings
 
+from iceaxe.modifications import MODIFICATION_TRACKER_VERBOSITY
+
 
 class DatabaseConfig(BaseSettings):
     """
@@ -35,4 +37,10 @@ class DatabaseConfig(BaseSettings):
     """
     The port number where PostgreSQL server is listening.
     Defaults to the standard PostgreSQL port 5432 if not specified.
+    """
+
+    ICEAXE_UNCOMMITTED_VERBOSITY: MODIFICATION_TRACKER_VERBOSITY | None = None
+    """
+    The verbosity level for uncommitted modifications.
+    If set to None, uncommitted modifications will not be tracked.
     """

--- a/iceaxe/mountaineer/dependencies/core.py
+++ b/iceaxe/mountaineer/dependencies/core.py
@@ -53,7 +53,9 @@ async def get_db_connection(
         password=config.POSTGRES_PASSWORD,
         database=config.POSTGRES_DB,
     )
-    connection = DBConnection(conn)
+    connection = DBConnection(
+        conn, uncommitted_verbosity=config.ICEAXE_UNCOMMITTED_VERBOSITY
+    )
     try:
         yield connection
     finally:

--- a/iceaxe/session.py
+++ b/iceaxe/session.py
@@ -81,6 +81,7 @@ class DBConnection:
     def __init__(
         self,
         conn: asyncpg.Connection,
+        *,
         uncommitted_verbosity: Literal["ERROR", "WARNING", "INFO"] | None = None,
     ):
         """


### PR DESCRIPTION
- Support functions in group_by. Much like order_by, they're allowed if they're fully qualified
- Expose verbosity of uncommitted logging in the Mountaineer Config
- Fix JSON parsing of update values in `update` and return values in `upsert`