### PR TITLE
Optimize insertion speed

### DIFF
--- a/iceaxe/__tests__/benchmarks/test_bulk_insert.py
+++ b/iceaxe/__tests__/benchmarks/test_bulk_insert.py
@@ -1,0 +1,53 @@
+import asyncio
+import time
+from typing import Sequence
+
+import pytest
+
+from iceaxe.__tests__.conf_models import UserDemo
+from iceaxe.session import DBConnection
+
+from iceaxe.logging import CONSOLE, LOGGER
+
+def generate_test_users(count: int) -> Sequence[UserDemo]:
+    """
+    Generate a sequence of test users for bulk insertion.
+    
+    :param count: Number of users to generate
+    :return: Sequence of UserDemo instances
+    """
+    return [
+        UserDemo(
+            name=f"User {i}",
+            email=f"user{i}@example.com"
+        )
+        for i in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.benchmark
+async def test_bulk_insert_performance(db_connection: DBConnection):
+    """
+    Test the performance of bulk inserting 500k records.
+    """
+    # Generate 500k test users
+    NUM_USERS = 500_000
+    users = generate_test_users(NUM_USERS)
+    LOGGER.info(f"Generated {NUM_USERS} test users")
+    
+    # Time the insertion
+    start_time = time.time()
+    
+    await db_connection.insert(users)
+
+    total_time = time.time() - start_time
+    records_per_second = NUM_USERS / total_time
+    
+    CONSOLE.print(f"\nBulk Insert Performance:")
+    CONSOLE.print(f"Total time: {total_time:.2f} seconds")
+    CONSOLE.print(f"Records per second: {records_per_second:.2f}")
+    
+    # Verify the count
+    result = await db_connection.conn.fetchval("SELECT COUNT(*) FROM userdemo")
+    assert result == NUM_USERS 

--- a/iceaxe/__tests__/benchmarks/test_bulk_insert.py
+++ b/iceaxe/__tests__/benchmarks/test_bulk_insert.py
@@ -1,27 +1,22 @@
-import asyncio
 import time
 from typing import Sequence
 
 import pytest
 
 from iceaxe.__tests__.conf_models import UserDemo
+from iceaxe.logging import CONSOLE, LOGGER
 from iceaxe.session import DBConnection
 
-from iceaxe.logging import CONSOLE, LOGGER
 
 def generate_test_users(count: int) -> Sequence[UserDemo]:
     """
     Generate a sequence of test users for bulk insertion.
-    
+
     :param count: Number of users to generate
     :return: Sequence of UserDemo instances
     """
     return [
-        UserDemo(
-            name=f"User {i}",
-            email=f"user{i}@example.com"
-        )
-        for i in range(count)
+        UserDemo(name=f"User {i}", email=f"user{i}@example.com") for i in range(count)
     ]
 
 
@@ -35,19 +30,19 @@ async def test_bulk_insert_performance(db_connection: DBConnection):
     NUM_USERS = 500_000
     users = generate_test_users(NUM_USERS)
     LOGGER.info(f"Generated {NUM_USERS} test users")
-    
+
     # Time the insertion
     start_time = time.time()
-    
+
     await db_connection.insert(users)
 
     total_time = time.time() - start_time
     records_per_second = NUM_USERS / total_time
-    
-    CONSOLE.print(f"\nBulk Insert Performance:")
+
+    CONSOLE.print("\nBulk Insert Performance:")
     CONSOLE.print(f"Total time: {total_time:.2f} seconds")
     CONSOLE.print(f"Records per second: {records_per_second:.2f}")
-    
+
     # Verify the count
     result = await db_connection.conn.fetchval("SELECT COUNT(*) FROM userdemo")
-    assert result == NUM_USERS 
+    assert result == NUM_USERS

--- a/iceaxe/__tests__/benchmarks/test_bulk_insert.py
+++ b/iceaxe/__tests__/benchmarks/test_bulk_insert.py
@@ -21,17 +21,15 @@ def generate_test_users(count: int) -> Sequence[UserDemo]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.benchmark
+@pytest.mark.integration_tests
 async def test_bulk_insert_performance(db_connection: DBConnection):
     """
     Test the performance of bulk inserting 500k records.
     """
-    # Generate 500k test users
     NUM_USERS = 500_000
     users = generate_test_users(NUM_USERS)
     LOGGER.info(f"Generated {NUM_USERS} test users")
 
-    # Time the insertion
     start_time = time.time()
 
     await db_connection.insert(users)
@@ -43,6 +41,5 @@ async def test_bulk_insert_performance(db_connection: DBConnection):
     CONSOLE.print(f"Total time: {total_time:.2f} seconds")
     CONSOLE.print(f"Records per second: {records_per_second:.2f}")
 
-    # Verify the count
     result = await db_connection.conn.fetchval("SELECT COUNT(*) FROM userdemo")
     assert result == NUM_USERS

--- a/iceaxe/session.py
+++ b/iceaxe/session.py
@@ -11,6 +11,7 @@ from typing import (
     cast,
     overload,
 )
+from math import ceil
 
 import asyncpg
 from typing_extensions import TypeVarTuple
@@ -210,7 +211,7 @@ class DBConnection:
 
         return None
 
-    async def insert(self, objects: Sequence[TableBase]):
+    async def insert(self, objects: Sequence[TableBase], MAX_BATCH_SIZE: int = 5000):
         """
         Insert one or more model instances into the database. If the model has an auto-incrementing
         primary key, it will be populated on the instances after insertion.
@@ -235,37 +236,83 @@ class DBConnection:
         if not objects:
             return
 
-        for model, model_objects in self._aggregate_models_by_table(objects):
-            table_name = QueryIdentifier(model.get_table_name())
-            fields = {
-                field: info
-                for field, info in model.model_fields.items()
-                if (not info.exclude and not info.autoincrement)
-            }
-            field_string = ", ".join(f'"{field}"' for field in fields)
-            primary_key = self._get_primary_key(model)
+        # Reuse a single transaction for all inserts
+        async with self._ensure_transaction():
+            for model, model_objects in self._aggregate_models_by_table(objects):
+                # For each table, build batched insert queries
+                table_name = QueryIdentifier(model.get_table_name())
+                fields = {
+                    field: info
+                    for field, info in model.model_fields.items()
+                    if (not info.exclude and not info.autoincrement)
+                }
+                primary_key = self._get_primary_key(model)
+                field_names = list(fields.keys())  # Iterate over these in order for each row
+                field_identifiers = ", ".join(f'"{f}"' for f in field_names)
 
-            placeholders = ", ".join(f"${i}" for i in range(1, len(fields) + 1))
-            query = f"INSERT INTO {table_name} ({field_string}) VALUES ({placeholders})"
-            if primary_key:
-                query += f" RETURNING {primary_key}"
+                total = len(model_objects)
+                num_batches = ceil(total / MAX_BATCH_SIZE)
 
-            async with self._ensure_transaction():
-                for obj in model_objects:
-                    obj_values = obj.model_dump()
-                    values = [
-                        info.to_db_value(obj_values[field])
-                        for field, info in fields.items()
-                    ]
-                    result = await self.conn.fetchrow(query, *values)
+                for batch_idx in range(num_batches):
+                    start_idx = batch_idx * MAX_BATCH_SIZE
+                    end_idx = (batch_idx + 1) * MAX_BATCH_SIZE
+                    batch_objects = model_objects[start_idx:end_idx]
 
-                    if primary_key and result:
-                        setattr(obj, primary_key, result[primary_key])
-                    obj.clear_modified_attributes()
+                    # Build the multi-row VALUES clause
+                    # e.g. for 3 rows with 2 columns, we'd want:
+                    #   VALUES ($1, $2), ($3, $4), ($5, $6)
+                    num_rows = len(batch_objects)
+                    if not num_rows:
+                        continue
 
+                    # placeholders per row: ($1, $2, ...)
+                    # but we have to shift the placeholder index for each row
+                    placeholders : list[str] = []
+                    values : list[Any] = []
+                    param_index = 1
+
+                    for obj in batch_objects:
+                        obj_values = obj.model_dump()
+                        row_values = []
+                        for field in field_names:
+                            info = fields[field]
+                            row_values.append(info.to_db_value(obj_values[field]))
+                        values.extend(row_values)
+                        row_placeholder = (
+                            "(" + ", ".join(f"${p}" for p in range(param_index, param_index + len(field_names))) + ")"
+                        )
+                        placeholders.append(row_placeholder)
+                        param_index += len(field_names)
+
+                    placeholders_clause = ", ".join(placeholders)
+
+                    query = f"""
+                        INSERT INTO {table_name} ({field_identifiers})
+                        VALUES {placeholders_clause}
+                    """
+                    if primary_key:
+                        query += f" RETURNING {primary_key}"
+
+                    # Insert them in one go
+                    if primary_key:
+                        rows = await self.conn.fetch(query, *values)
+                        # 'rows' should be a list of Record objects, one per inserted row
+                        # Update each object in the same order
+                        for obj, row in zip(batch_objects, rows):
+                            setattr(obj, primary_key, row[primary_key])
+                    else:
+                        # No need to fetch anything if there's no primary key
+                        await self.conn.execute(query, *values)
+
+                    # Mark as unmodified
+                    for obj in batch_objects:
+                        obj.clear_modified_attributes()
+
+        # Register modification callbacks outside the main insert loop
         for obj in objects:
             obj.register_modified_callback(self.modification_tracker.track_modification)
 
+        # Clear modification status
         self.modification_tracker.clear_status(objects)
 
     @overload


### PR DESCRIPTION
Add benchmarking for our insert performance. In the current shipping version this benchmarks to 5000rows/s. After this PR we reach speeds >100k. We adjust each batch insertion to maximize the amount of bin-packing possible given Postgres' variable limit within one query.

```
Bulk Insert Performance:
Total time: 4.97 seconds
Records per second: 100691.43
```