### PR TITLE
Add destination table/col to migration dependencies

### DIFF
--- a/iceaxe/__tests__/schemas/test_db_memory_serializer.py
+++ b/iceaxe/__tests__/schemas/test_db_memory_serializer.py
@@ -1361,6 +1361,13 @@ async def test_foreign_key_table_dependency():
         and obj.table_name == "targetmodel"
         and obj.column_name == "id"
     )
+    target_pk_pos = next(
+        i
+        for i, obj in enumerate(sorted_objects)
+        if isinstance(obj, DBConstraint)
+        and obj.constraint_type == ConstraintType.PRIMARY_KEY
+        and obj.table_name == "targetmodel"
+    )
     fk_constraint_pos = next(
         i
         for i, obj in enumerate(sorted_objects)
@@ -1379,6 +1386,9 @@ async def test_foreign_key_table_dependency():
     assert (
         target_column_pos < fk_constraint_pos
     ), "Foreign key constraint should be created after target column"
+    assert (
+        target_pk_pos < fk_constraint_pos
+    ), "Foreign key constraint should be created after target primary key"
 
     # Verify the actual migration actions
     actor = DatabaseActions()

--- a/iceaxe/__tests__/schemas/test_db_memory_serializer.py
+++ b/iceaxe/__tests__/schemas/test_db_memory_serializer.py
@@ -1314,3 +1314,105 @@ def test_primary_key_not_null(clear_all_database_objects):
     )
     assert not auto_id_column.nullable
     assert auto_id_column.autoincrement
+
+
+@pytest.mark.asyncio
+async def test_foreign_key_table_dependency():
+    """
+    Test that foreign key constraints properly depend on the referenced table being created first.
+    This test verifies that the foreign key constraint is ordered after both tables are created.
+    """
+
+    class TargetModel(TableBase):
+        id: int = Field(primary_key=True)
+        value: str
+
+    class SourceModel(TableBase):
+        id: int = Field(primary_key=True)
+        target_id: int = Field(foreign_key="targetmodel.id")
+
+    migrator = DatabaseMemorySerializer()
+
+    # Make sure Source is parsed before Target so we can make sure our foreign-key
+    # constraint actually re-orders the final objects.
+    db_objects = list(migrator.delegate([SourceModel, TargetModel]))
+    ordering = migrator.order_db_objects(db_objects)
+
+    # Get all objects in their sorted order
+    sorted_objects = sorted(
+        [obj for obj, _ in db_objects], key=lambda obj: ordering[obj]
+    )
+
+    # Find the positions of key objects
+    target_table_pos = next(
+        i
+        for i, obj in enumerate(sorted_objects)
+        if isinstance(obj, DBTable) and obj.table_name == "targetmodel"
+    )
+    source_table_pos = next(
+        i
+        for i, obj in enumerate(sorted_objects)
+        if isinstance(obj, DBTable) and obj.table_name == "sourcemodel"
+    )
+    target_column_pos = next(
+        i
+        for i, obj in enumerate(sorted_objects)
+        if isinstance(obj, DBColumn)
+        and obj.table_name == "targetmodel"
+        and obj.column_name == "id"
+    )
+    fk_constraint_pos = next(
+        i
+        for i, obj in enumerate(sorted_objects)
+        if isinstance(obj, DBConstraint)
+        and obj.constraint_type == ConstraintType.FOREIGN_KEY
+        and obj.table_name == "sourcemodel"
+    )
+
+    # The foreign key constraint should come after both tables and the target column are created
+    assert (
+        target_table_pos < fk_constraint_pos
+    ), "Foreign key constraint should be created after target table"
+    assert (
+        source_table_pos < fk_constraint_pos
+    ), "Foreign key constraint should be created after source table"
+    assert (
+        target_column_pos < fk_constraint_pos
+    ), "Foreign key constraint should be created after target column"
+
+    # Verify the actual migration actions
+    actor = DatabaseActions()
+    actions = await migrator.build_actions(
+        actor, [], {}, [obj for obj, _ in db_objects], ordering
+    )
+
+    # Extract the table creation and foreign key constraint actions
+    table_creations = [
+        action
+        for action in actions
+        if isinstance(action, DryRunAction) and action.fn == actor.add_table
+    ]
+    fk_constraints = [
+        action
+        for action in actions
+        if isinstance(action, DryRunAction)
+        and action.fn == actor.add_constraint
+        and action.kwargs.get("constraint") == ConstraintType.FOREIGN_KEY
+    ]
+
+    # Verify that table creations come before foreign key constraints
+    assert len(table_creations) == 2
+    assert len(fk_constraints) == 1
+
+    table_creation_indices = [
+        i for i, action in enumerate(actions) if action in table_creations
+    ]
+    fk_constraint_indices = [
+        i for i, action in enumerate(actions) if action in fk_constraints
+    ]
+
+    assert all(
+        table_idx < fk_idx
+        for table_idx in table_creation_indices
+        for fk_idx in fk_constraint_indices
+    )

--- a/iceaxe/migrations/action_sorter.py
+++ b/iceaxe/migrations/action_sorter.py
@@ -20,7 +20,7 @@ class ActionTopologicalSorter:
         self.in_degree = defaultdict(int)
         self.nodes = set(graph.keys())
 
-        for node, dependencies in graph.items():
+        for node, dependencies in list(graph.items()):
             for dep in dependencies:
                 self.in_degree[node] += 1
                 if dep not in self.nodes:

--- a/iceaxe/migrations/cli.py
+++ b/iceaxe/migrations/cli.py
@@ -4,9 +4,6 @@ from time import monotonic_ns
 from iceaxe.base import DBModelMetaclass, TableBase
 from iceaxe.io import resolve_package_path
 from iceaxe.logging import CONSOLE
-from iceaxe.migrations.client_io import fetch_migrations, sort_migrations
-from iceaxe.migrations.generator import MigrationGenerator
-from iceaxe.migrations.migrator import Migrator
 from iceaxe.schemas.db_serializer import DatabaseSerializer
 from iceaxe.session import DBConnection
 
@@ -35,6 +32,11 @@ async def handle_generate(
         handle_generate("my_project", db_connection, message=message)
     ```
     """
+    # Any local imports must be done here to avoid circular imports because migrations.__init__
+    # imports this file.
+    from iceaxe.migrations.client_io import fetch_migrations
+    from iceaxe.migrations.generator import MigrationGenerator
+    from iceaxe.migrations.migrator import Migrator
 
     CONSOLE.print("[bold blue]Generating migration to current schema")
 
@@ -122,6 +124,8 @@ async def handle_apply(
         project that's specified in pyproject.toml or setup.py.
 
     """
+    from iceaxe.migrations.client_io import fetch_migrations, sort_migrations
+    from iceaxe.migrations.migrator import Migrator
 
     migrations_path = resolve_package_path(package) / "migrations"
     if not migrations_path.exists():
@@ -178,6 +182,8 @@ async def handle_rollback(
         project that's specified in pyproject.toml or setup.py.
 
     """
+    from iceaxe.migrations.client_io import fetch_migrations, sort_migrations
+    from iceaxe.migrations.migrator import Migrator
 
     migrations_path = resolve_package_path(package) / "migrations"
     if not migrations_path.exists():

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -467,17 +467,19 @@ class DatabaseHandler:
                     # Ensure the primary key constraint exists before the foreign key
                     # constraint. Postgres also accepts a unique constraint on the same.
                     DBPointerOr(
-                        *[
-                            DBConstraintPointer(
-                                table_name=target_table,
-                                columns=frozenset([target_column]),
-                                constraint_type=constraint_type,
-                            )
-                            for constraint_type in [
-                                ConstraintType.PRIMARY_KEY,
-                                ConstraintType.UNIQUE,
+                        pointers=tuple(
+                            [
+                                DBConstraintPointer(
+                                    table_name=target_table,
+                                    columns=frozenset([target_column]),
+                                    constraint_type=constraint_type,
+                                )
+                                for constraint_type in [
+                                    ConstraintType.PRIMARY_KEY,
+                                    ConstraintType.UNIQUE,
+                                ]
                             ]
-                        ]
+                        ),
                     ),
                 ],
             )

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -432,8 +432,8 @@ class DatabaseHandler:
                     ),
                 ),
                 dependencies=[
+                    # Additional dependencies to ensure the target table/column is created first
                     DBTable(table_name=target_table),
-                    DBTable(table_name=table.get_table_name()),
                     DBColumnPointer(
                         table_name=target_table,
                         column_name=target_column,

--- a/iceaxe/schemas/db_stubs.py
+++ b/iceaxe/schemas/db_stubs.py
@@ -400,9 +400,6 @@ class DBPointerOr(DBObjectPointer):
 
     pointers: tuple[DBObjectPointer, ...]
 
-    def __init__(self, *pointers: DBObjectPointer):
-        self.pointers = pointers
-
     def representation(self) -> str:
         # Sort the representations to ensure consistent ordering
         return "OR(" + ",".join(sorted(p.representation() for p in self.pointers)) + ")"

--- a/iceaxe/schemas/db_stubs.py
+++ b/iceaxe/schemas/db_stubs.py
@@ -374,3 +374,35 @@ class DBType(DBTypeBase, DBObject):
             values=self.values,
             reference_columns=self.reference_columns | other.reference_columns,
         )
+
+
+class DBConstraintPointer(DBObjectPointer):
+    """
+    A pointer to a constraint that will be created. Used for dependency tracking
+    without needing to know the full constraint definition.
+    """
+
+    table_name: str
+    columns: frozenset[str]
+    constraint_type: ConstraintType
+
+    def representation(self) -> str:
+        # Match the representation of DBConstraint
+        return f"{self.table_name}.{sorted(self.columns)}.{self.constraint_type}"
+
+
+class DBPointerOr(DBObjectPointer):
+    """
+    A pointer that represents an OR relationship between multiple pointers.
+    When resolving dependencies, any of the provided pointers being present
+    will satisfy the dependency.
+    """
+
+    pointers: tuple[DBObjectPointer, ...]
+
+    def __init__(self, *pointers: DBObjectPointer):
+        self.pointers = pointers
+
+    def representation(self) -> str:
+        # Sort the representations to ensure consistent ordering
+        return "OR(" + ",".join(sorted(p.representation() for p in self.pointers)) + ")"


### PR DESCRIPTION
When specifying foreign keys that require cross-table dependencies, it's important to create their dependent table/column before we create our constraint. This PR adds support for doing that either for foreign primary keys or foreign unique constraints - both of which Postgres supports.