### PR TITLE
Distinct equality can't be used with full joins

### DIFF
--- a/iceaxe/__tests__/test_queries.py
+++ b/iceaxe/__tests__/test_queries.py
@@ -102,7 +102,7 @@ def test_join():
         .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id)
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" AS "userdemo_id", "artifactdemo"."title" AS "artifactdemo_title" FROM "userdemo" INNER JOIN "artifactdemo" ON "userdemo"."id" IS NOT DISTINCT FROM "artifactdemo"."user_id"',
+        'SELECT "userdemo"."id" AS "userdemo_id", "artifactdemo"."title" AS "artifactdemo_title" FROM "userdemo" INNER JOIN "artifactdemo" ON "userdemo"."id" = "artifactdemo"."user_id"',
         [],
     )
 
@@ -114,7 +114,7 @@ def test_left_join():
         .join(ArtifactDemo, UserDemo.id == ArtifactDemo.user_id, "LEFT")
     )
     assert new_query.build() == (
-        'SELECT "userdemo"."id" AS "userdemo_id", "artifactdemo"."title" AS "artifactdemo_title" FROM "userdemo" LEFT JOIN "artifactdemo" ON "userdemo"."id" IS NOT DISTINCT FROM "artifactdemo"."user_id"',
+        'SELECT "userdemo"."id" AS "userdemo_id", "artifactdemo"."title" AS "artifactdemo_title" FROM "userdemo" LEFT JOIN "artifactdemo" ON "userdemo"."id" = "artifactdemo"."user_id"',
         [],
     )
 
@@ -525,7 +525,7 @@ def test_for_update_multiple_of():
     assert new_query.build() == (
         'SELECT "userdemo"."id" AS "userdemo_id", "userdemo"."name" AS "userdemo_name", "userdemo"."email" AS "userdemo_email", '
         '"artifactdemo"."id" AS "artifactdemo_id", "artifactdemo"."title" AS "artifactdemo_title", "artifactdemo"."user_id" AS "artifactdemo_user_id" '
-        'FROM "userdemo" INNER JOIN "artifactdemo" ON "userdemo"."id" IS NOT DISTINCT FROM "artifactdemo"."user_id" '
+        'FROM "userdemo" INNER JOIN "artifactdemo" ON "userdemo"."id" = "artifactdemo"."user_id" '
         'FOR UPDATE OF "artifactdemo", "userdemo"',
         [],
     )

--- a/iceaxe/queries.py
+++ b/iceaxe/queries.py
@@ -677,9 +677,12 @@ class QueryBuilder(Generic[P, QueryType]):
                 f"Invalid join condition: {on}, should be MyTable.column == OtherTable.column"
             )
 
-        on_left, _ = on.left.to_query()
-        comparison = QueryLiteral(on.comparison.value)
-        on_right, _ = on.right.to_query()
+        # Let the comparison update to handle its current usage in a join
+        on_join = on.force_join_constraints()
+
+        on_left, _ = on_join.left.to_query()
+        comparison = QueryLiteral(on_join.comparison.value)
+        on_right, _ = on_join.right.to_query()
 
         join_sql = f"{join_type} JOIN {sql(table)} ON {on_left} {comparison} {on_right}"
         self._join_clauses.append(join_sql)


### PR DESCRIPTION
`IS DISTINCT FROM` is not fully supported in JOIN. Specifically in FULL join types which fail with:

> FULL JOIN is only supported with merge-joinable or hash-joinable join conditions

In this PR, we exclude the logic that we added in https://github.com/piercefreeman/iceaxe/pull/74 when column equality is used in a `JOIN` clause. If users want to override this default they can explicitly provide the .is_distinct_from operator in their column comparison:

```python
.join(
  column(model.MyModel.col1).is_distinct_from(model.MyModel.col2)
)
```

All explicit operations like these will have `python_expression=False` which will pass through the logic as originally specified to the join clause.