### PR TITLE
Call explicit getattr instead of superclass

### DIFF
--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -4,6 +4,7 @@ from iceaxe.base import (
     DBModelMetaclass,
     TableBase,
 )
+from iceaxe.field import DBFieldInfo
 
 
 def test_autodetect():
@@ -30,3 +31,22 @@ def test_not_autodetect_generic(clear_registry):
         pass
 
     assert DBModelMetaclass.get_registry() == [WillAutodetect]
+
+
+def test_model_fields():
+    class User(TableBase):
+        id: int
+        name: str
+
+    # Check the main fields
+    assert isinstance(User.model_fields["id"], DBFieldInfo)
+    assert User.model_fields["id"].annotation == int  # noqa: E721
+    assert User.model_fields["id"].is_required() is True
+
+    assert isinstance(User.model_fields["name"], DBFieldInfo)
+    assert User.model_fields["name"].annotation == str  # noqa: E721
+    assert User.model_fields["name"].is_required() is True
+
+    # Check that the special fields exist with the right types
+    assert isinstance(User.model_fields["modified_attrs"], DBFieldInfo)
+    assert isinstance(User.model_fields["modified_attrs_callbacks"], DBFieldInfo)

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -152,7 +152,7 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
 
         :return: Dictionary of field names to field definitions
         """
-        return super().model_fields  # type: ignore
+        return getattr(self, "__pydantic_fields__", {})  # type: ignore
 
 
 class UniqueConstraint(BaseModel):


### PR DESCRIPTION
Avoid recursion of getattr calls.

```
File "/Users/piercefreeman/projects/playbook/playbook_server/.venv/lib/python3.12/site-packages/iceaxe/base.py", line 107, in __getattr__
    if key in self.model_fields:
              ^^^^^^^^^^^^^^^^^
  File "/Users/piercefreeman/projects/playbook/playbook_server/.venv/lib/python3.12/site-packages/iceaxe/base.py", line 107, in __getattr__
    if key in self.model_fields:
              ^^^^^^^^^^^^^^^^^
  [Previous line repeated 735 more times]
  File "/Users/piercefreeman/projects/playbook/playbook_server/.venv/lib/python3.12/site-packages/iceaxe/base.py", line 155, in model_fields
    return super().model_fields  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded while calling a Python object
Normalization failed: type=AttributeError args=<unknown>
```