### PR TITLE
Fix pydantic deprecation notice for 2.11

### DIFF
--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -273,7 +273,7 @@ class TableBase(BaseModel, metaclass=DBModelMetaclass):
         :param name: Attribute name
         :param value: New value
         """
-        if name in self.model_fields:
+        if name in self.__class__.model_fields:
             self.modified_attrs[name] = value
             for callback in self.modified_attrs_callbacks:
                 callback(self)

--- a/iceaxe/session.py
+++ b/iceaxe/session.py
@@ -593,7 +593,7 @@ class DBConnection:
                     modified_attrs = frozenset(
                         k
                         for k, v in obj.get_modified_attributes().items()
-                        if not obj.model_fields[k].exclude
+                        if not obj.__class__.model_fields[k].exclude
                     )
                     if modified_attrs:
                         updates_by_fields[modified_attrs].append(obj)


### PR DESCRIPTION
Fix deprecation warning triggered by accessing the model fields directly instead of on the class:

```
PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    if name in self.model_fields:
```