### PR TITLE
Alias timestamp to without timezone

### DIFF
--- a/iceaxe/__tests__/schemas/test_actions.py
+++ b/iceaxe/__tests__/schemas/test_actions.py
@@ -263,8 +263,8 @@ async def test_add_column_any_type(
         (ColumnType.SERIAL, ColumnType.INTEGER),
         (ColumnType.BIGSERIAL, ColumnType.BIGINT),
         (ColumnType.CHAR, "character"),
-        (ColumnType.TIME, "time without time zone"),
-        (ColumnType.TIMESTAMP, "timestamp without time zone"),
+        (ColumnType.TIME_WITHOUT_TIME_ZONE, "time without time zone"),
+        (ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE, "timestamp without time zone"),
     )
 
     allowed_values = {enum_value.value}
@@ -365,7 +365,7 @@ async def test_modify_column_type(
         (ColumnType.VARCHAR, ColumnType.DATE, "2023-01-01", "2023-01-01", True),
         (
             ColumnType.TEXT,
-            ColumnType.TIMESTAMP,
+            ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
             "2023-01-01 12:00:00",
             "2023-01-01 12:00:00",
             True,
@@ -443,7 +443,7 @@ async def test_modify_column_type_with_autocast(
     actual_value = row[column_name]
     if isinstance(expected_value, str) and to_type in [
         ColumnType.DATE,
-        ColumnType.TIMESTAMP,
+        ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
     ]:
         # For date/timestamp, convert to string for comparison
         actual_value = str(actual_value)
@@ -1158,7 +1158,7 @@ async def test_modify_column_type_date_to_timestamp(
     await db_backed_actions.modify_column_type(
         table_name,
         column_name,
-        explicit_data_type=ColumnType.TIMESTAMP,
+        explicit_data_type=ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
         autocast=False,
     )
 

--- a/iceaxe/__tests__/schemas/test_db_memory_serializer.py
+++ b/iceaxe/__tests__/schemas/test_db_memory_serializer.py
@@ -750,7 +750,7 @@ def test_enum_column_assignment(clear_all_database_objects):
                     DBColumn(
                         table_name="exampledbmodel",
                         column_name="standard_datetime",
-                        column_type=ColumnType.TIMESTAMP,
+                        column_type=ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
                         column_is_list=False,
                         nullable=False,
                     ),
@@ -810,7 +810,7 @@ def test_enum_column_assignment(clear_all_database_objects):
                     DBColumn(
                         table_name="exampledbmodel",
                         column_name="standard_time",
-                        column_type=ColumnType.TIME,
+                        column_type=ColumnType.TIME_WITHOUT_TIME_ZONE,
                         column_is_list=False,
                         nullable=False,
                     ),

--- a/iceaxe/__tests__/schemas/test_db_serializer.py
+++ b/iceaxe/__tests__/schemas/test_db_serializer.py
@@ -143,6 +143,52 @@ class ValueEnumInt(IntEnum):
                 )
             ],
         ),
+        # Test PostgreSQL's storage format for timestamp without timezone
+        (
+            """
+            CREATE TABLE exampledbmodel (
+                id SERIAL PRIMARY KEY,
+                created_at TIMESTAMP NOT NULL
+            );
+            """,
+            [
+                (
+                    DBColumn(
+                        table_name="exampledbmodel",
+                        column_name="created_at",
+                        column_type=ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
+                        column_is_list=False,
+                        nullable=False,
+                    ),
+                    [
+                        DBTable(table_name="exampledbmodel"),
+                    ],
+                )
+            ],
+        ),
+        # Test PostgreSQL's storage format for timestamp with timezone
+        (
+            """
+            CREATE TABLE exampledbmodel (
+                id SERIAL PRIMARY KEY,
+                created_at TIMESTAMPTZ NOT NULL
+            );
+            """,
+            [
+                (
+                    DBColumn(
+                        table_name="exampledbmodel",
+                        column_name="created_at",
+                        column_type=ColumnType.TIMESTAMP_WITH_TIME_ZONE,
+                        column_is_list=False,
+                        nullable=False,
+                    ),
+                    [
+                        DBTable(table_name="exampledbmodel"),
+                    ],
+                )
+            ],
+        ),
     ],
 )
 async def test_simple_db_serializer(

--- a/iceaxe/__tests__/test_comparison.py
+++ b/iceaxe/__tests__/test_comparison.py
@@ -380,4 +380,4 @@ def test_postgres_datetime_timezone_casting(
     """
 
     # Test that ColumnType enum can handle PostgreSQL's storage formats and aliases
-    assert ColumnType.from_sql_type(sql_type_string) == expected_column_type
+    assert ColumnType(sql_type_string) == expected_column_type

--- a/iceaxe/__tests__/test_comparison.py
+++ b/iceaxe/__tests__/test_comparison.py
@@ -10,6 +10,7 @@ from iceaxe.base import TableBase
 from iceaxe.comparison import ComparisonType, FieldComparison
 from iceaxe.field import DBFieldClassDefinition, DBFieldInfo
 from iceaxe.queries_str import QueryLiteral
+from iceaxe.sql_types import ColumnType
 from iceaxe.typing import column
 
 
@@ -354,3 +355,29 @@ def test_force_join_constraints(
     )
     forced = comparison.force_join_constraints()
     assert forced.comparison == expected_comparison
+
+
+@pytest.mark.parametrize(
+    "sql_type_string, expected_column_type",
+    [
+        ("timestamp", ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE),  # Tests aliasing
+        ("timestamp without time zone", ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE),
+        ("timestamp with time zone", ColumnType.TIMESTAMP_WITH_TIME_ZONE),
+        ("time", ColumnType.TIME_WITHOUT_TIME_ZONE),  # Tests aliasing
+        ("time without time zone", ColumnType.TIME_WITHOUT_TIME_ZONE),
+        ("time with time zone", ColumnType.TIME_WITH_TIME_ZONE),
+    ],
+)
+def test_postgres_datetime_timezone_casting(
+    sql_type_string: str, expected_column_type: ColumnType
+):
+    """
+    Test that PostgresDateTime fields with different timezone configurations
+    are properly handled by the ColumnType enum, specifically testing that
+    PostgreSQL's storage format ('timestamp without time zone') can be parsed.
+    This also tests that SQL standard aliases like "timestamp" correctly map
+    to "timestamp without time zone".
+    """
+
+    # Test that ColumnType enum can handle PostgreSQL's storage formats and aliases
+    assert ColumnType.from_sql_type(sql_type_string) == expected_column_type

--- a/iceaxe/schemas/actions.py
+++ b/iceaxe/schemas/actions.py
@@ -408,8 +408,8 @@ class DatabaseActions:
                 return f"{column_name}::boolean"
             elif explicit_data_type in [
                 ColumnType.DATE,
-                ColumnType.TIMESTAMP,
-                ColumnType.TIME,
+                ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
+                ColumnType.TIME_WITHOUT_TIME_ZONE,
             ]:
                 # Date/time conversions
                 return f"{column_name}::{explicit_data_type.value}"

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -454,12 +454,12 @@ class DatabaseHandler:
                         primitive_type=(
                             ColumnType.TIMESTAMP_WITH_TIME_ZONE
                             if info.postgres_config.timezone
-                            else ColumnType.TIMESTAMP
+                            else ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE
                         )
                     )
                 # Assume no timezone if not specified
                 return TypeDeclarationResponse(
-                    primitive_type=ColumnType.TIMESTAMP,
+                    primitive_type=ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
                 )
             elif is_type_compatible(annotation, date):  # type: ignore
                 return TypeDeclarationResponse(
@@ -471,11 +471,11 @@ class DatabaseHandler:
                         primitive_type=(
                             ColumnType.TIME_WITH_TIME_ZONE
                             if info.postgres_config.timezone
-                            else ColumnType.TIME
+                            else ColumnType.TIME_WITHOUT_TIME_ZONE
                         ),
                     )
                 return TypeDeclarationResponse(
-                    primitive_type=ColumnType.TIME,
+                    primitive_type=ColumnType.TIME_WITHOUT_TIME_ZONE,
                 )
             elif is_type_compatible(annotation, timedelta):  # type: ignore
                 return TypeDeclarationResponse(

--- a/iceaxe/schemas/db_serializer.py
+++ b/iceaxe/schemas/db_serializer.py
@@ -119,9 +119,9 @@ class DatabaseSerializer:
                 yield column_type, column_type_deps
             elif row["data_type"] == "ARRAY":
                 column_is_list = True
-                column_type = ColumnType.from_sql_type(row["element_type"])
+                column_type = ColumnType(row["element_type"])
             else:
-                column_type = ColumnType.from_sql_type(row["data_type"])
+                column_type = ColumnType(row["data_type"])
 
             yield (
                 DBColumn(

--- a/iceaxe/schemas/db_serializer.py
+++ b/iceaxe/schemas/db_serializer.py
@@ -119,9 +119,9 @@ class DatabaseSerializer:
                 yield column_type, column_type_deps
             elif row["data_type"] == "ARRAY":
                 column_is_list = True
-                column_type = ColumnType(row["element_type"])
+                column_type = ColumnType.from_sql_type(row["element_type"])
             else:
-                column_type = ColumnType(row["data_type"])
+                column_type = ColumnType.from_sql_type(row["data_type"])
 
             yield (
                 DBColumn(

--- a/iceaxe/sql_types.py
+++ b/iceaxe/sql_types.py
@@ -90,22 +90,29 @@ class ColumnType(StrEnum):
     OID = "oid"
 
     @classmethod
-    def from_sql_type(cls, value: str) -> "ColumnType":
+    def _missing_(cls, value: object):
         """
-        Create a ColumnType from a SQL type string, handling SQL standard aliases.
+        Handle SQL standard aliases when the exact enum value is not found.
 
         The SQL standard requires that "timestamp" be equivalent to "timestamp without time zone"
         and "time" be equivalent to "time without time zone".
         """
+        # Only handle string values for SQL type aliases
+        if not isinstance(value, str):
+            return None
+
         aliases = {
             "timestamp": "timestamp without time zone",
             "time": "time without time zone",
         }
 
+        # Check if this is an alias we can resolve
         if value in aliases:
-            value = aliases[value]
+            # Return the actual enum member for the aliased value
+            return cls(aliases[value])
 
-        return cls(value)
+        # If not an alias, let the default enum behavior handle it
+        return None
 
 
 class ConstraintType(StrEnum):

--- a/iceaxe/sql_types.py
+++ b/iceaxe/sql_types.py
@@ -8,6 +8,10 @@ class ColumnType(StrEnum):
     # the column they can be case-insensitive, but when we're casting from
     # the database to memory they must align with the on-disk representation
     # which is lowercase.
+    #
+    # Note: The SQL standard requires that writing just "timestamp" be equivalent
+    # to "timestamp without time zone", and PostgreSQL honors that behavior.
+    # Similarly, "time" is equivalent to "time without time zone".
 
     # Numeric Types
     SMALLINT = "smallint"
@@ -33,9 +37,9 @@ class ColumnType(StrEnum):
 
     # Date/Time Types
     DATE = "date"
-    TIME = "time"
+    TIME_WITHOUT_TIME_ZONE = "time without time zone"
     TIME_WITH_TIME_ZONE = "time with time zone"
-    TIMESTAMP = "timestamp"
+    TIMESTAMP_WITHOUT_TIME_ZONE = "timestamp without time zone"
     TIMESTAMP_WITH_TIME_ZONE = "timestamp with time zone"
     INTERVAL = "interval"
 
@@ -85,6 +89,24 @@ class ColumnType(StrEnum):
     # Object Identifier Type
     OID = "oid"
 
+    @classmethod
+    def from_sql_type(cls, value: str) -> "ColumnType":
+        """
+        Create a ColumnType from a SQL type string, handling SQL standard aliases.
+
+        The SQL standard requires that "timestamp" be equivalent to "timestamp without time zone"
+        and "time" be equivalent to "time without time zone".
+        """
+        aliases = {
+            "timestamp": "timestamp without time zone",
+            "time": "time without time zone",
+        }
+
+        if value in aliases:
+            value = aliases[value]
+
+        return cls(value)
+
 
 class ConstraintType(StrEnum):
     PRIMARY_KEY = "PRIMARY KEY"
@@ -105,9 +127,9 @@ def get_python_to_sql_mapping():
         bool: ColumnType.BOOLEAN,
         bytes: ColumnType.BYTEA,
         UUID: ColumnType.UUID,
-        datetime: ColumnType.TIMESTAMP,
+        datetime: ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE,
         date: ColumnType.DATE,
-        time: ColumnType.TIME,
+        time: ColumnType.TIME_WITHOUT_TIME_ZONE,
         timedelta: ColumnType.INTERVAL,
     }
 


### PR DESCRIPTION
Follow the SQL standard to support both, with timestamp just a direct map to timestamp without timezone.

https://www.postgresql.org/docs/current/datatype-datetime.html