### PR TITLE
Build 3.13 wheels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_BUILD: cp311-* cp312-*
+          CIBW_BUILD: cp311-* cp312-* cp313-*
           CIBW_SKIP: "*-musllinux*"
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv and with python version ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6.3.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install uv and with python version ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6.3.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: uv run pytest -v --continue-on-collection-errors
@@ -46,9 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv with Python 3.13
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6.3.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: 3.13
       - name: Run lint
         run: make lint
@@ -63,9 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv with Python 3.13
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6.3.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: 3.13
 
       - name: Update version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         run: uv build --sdist
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_BUILD: cp311-* cp312-* cp313-*


### PR DESCRIPTION
Expand our prebuild wheels to support 3.13, because who wants to be compiling dependencies from scratch?