### PR TITLE
Support typehint overrides for column migrations

### DIFF
--- a/iceaxe/__tests__/schemas/test_actions.py
+++ b/iceaxe/__tests__/schemas/test_actions.py
@@ -262,6 +262,7 @@ async def test_add_column_any_type(
         (ColumnType.DECIMAL, ColumnType.NUMERIC),
         (ColumnType.SERIAL, ColumnType.INTEGER),
         (ColumnType.BIGSERIAL, ColumnType.BIGINT),
+        (ColumnType.SMALLSERIAL, ColumnType.SMALLINT),
         (ColumnType.CHAR, "character"),
         (ColumnType.TIME_WITHOUT_TIME_ZONE, "time without time zone"),
         (ColumnType.TIMESTAMP_WITHOUT_TIME_ZONE, "timestamp without time zone"),

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -76,6 +76,7 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
                     index=False,
                     check_expression=None,
                     is_json=False,
+                    explicit_type=None,
                 )
                 for field, info in cls.model_fields.items()
             }

--- a/iceaxe/field.py
+++ b/iceaxe/field.py
@@ -19,6 +19,7 @@ from pydantic_core import PydanticUndefined
 from iceaxe.comparison import ComparisonBase
 from iceaxe.postgres import PostgresFieldBase
 from iceaxe.queries_str import QueryIdentifier, QueryLiteral
+from iceaxe.sql_types import ColumnType
 
 if TYPE_CHECKING:
     from iceaxe.base import TableBase
@@ -37,6 +38,7 @@ class DBFieldInputs(_FieldInfoInputs, total=False):
     index: bool
     check_expression: str | None
     is_json: bool
+    explicit_type: ColumnType | None
 
 
 class DBFieldInfo(FieldInfo):
@@ -97,6 +99,12 @@ class DBFieldInfo(FieldInfo):
     When True, the field's value will be JSON serialized before storage.
     """
 
+    explicit_type: ColumnType | None = None
+    """
+    Explicitly specify the SQL column type for this field.
+    When set, this type takes precedence over automatic type inference.
+    """
+
     def __init__(self, **kwargs: Unpack[DBFieldInputs]):
         """
         Initialize a new DBFieldInfo instance with the given field configuration.
@@ -119,6 +127,7 @@ class DBFieldInfo(FieldInfo):
         self.index = kwargs.pop("index", False)
         self.check_expression = kwargs.pop("check_expression", None)
         self.is_json = kwargs.pop("is_json", False)
+        self.explicit_type = kwargs.pop("explicit_type", None)
 
     @classmethod
     def extend_field(
@@ -131,6 +140,7 @@ class DBFieldInfo(FieldInfo):
         index: bool,
         check_expression: str | None,
         is_json: bool,
+        explicit_type: ColumnType | None,
     ):
         """
         Helper function to extend a Pydantic FieldInfo with database-specific attributes.
@@ -144,6 +154,7 @@ class DBFieldInfo(FieldInfo):
             index=index,
             check_expression=check_expression,
             is_json=is_json,
+            explicit_type=explicit_type,
             **field._attributes_set,  # type: ignore
         )
 
@@ -168,6 +179,7 @@ def __get_db_field(_: Callable[Concatenate[Any, P], Any] = PydanticField):  # ty
         index: bool = False,
         check_expression: str | None = None,
         is_json: bool = False,
+        explicit_type: ColumnType | None = None,
         default: Any = _Unset,
         default_factory: (
             Callable[[], Any] | Callable[[dict[str, Any]], Any] | None
@@ -192,6 +204,7 @@ def __get_db_field(_: Callable[Concatenate[Any, P], Any] = PydanticField):  # ty
                 index=index,
                 check_expression=check_expression,
                 is_json=is_json,
+                explicit_type=explicit_type,
             ),
         )
 

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -415,6 +415,12 @@ class DatabaseHandler:
         if info.annotation is None:
             raise ValueError(f"Annotation must be provided for {table.__name__}.{key}")
 
+        # If explicit_type is provided, use it directly as the preferred type
+        if info.explicit_type is not None:
+            return TypeDeclarationResponse(
+                primitive_type=info.explicit_type,
+            )
+
         annotation = remove_null_type(info.annotation)
 
         # Resolve the type of the column, if generic

--- a/iceaxe/schemas/db_stubs.py
+++ b/iceaxe/schemas/db_stubs.py
@@ -253,6 +253,10 @@ class DBColumn(DBColumnBase, DBObject["DBColumn"]):
         if isinstance(self.column_type, ColumnType):
             if self.column_type == ColumnType.INTEGER and self.autoincrement:
                 explicit_data_type = ColumnType.SERIAL
+            elif self.column_type == ColumnType.BIGINT and self.autoincrement:
+                explicit_data_type = ColumnType.BIGSERIAL
+            elif self.column_type == ColumnType.SMALLINT and self.autoincrement:
+                explicit_data_type = ColumnType.SMALLSERIAL
             else:
                 explicit_data_type = self.column_type
 

--- a/iceaxe/sql_types.py
+++ b/iceaxe/sql_types.py
@@ -23,6 +23,7 @@ class ColumnType(StrEnum):
     DOUBLE_PRECISION = "double precision"
     SERIAL = "serial"
     BIGSERIAL = "bigserial"
+    SMALLSERIAL = "smallserial"
 
     # Monetary Type
     MONEY = "money"


### PR DESCRIPTION
We default our python types to the Postgres standard types (python int to postgres integer). But on the postgres side these values are only i32 by default. BIGINT is required as an explicit type definition to unlock the 64bit values. We add support for explicitly selecting the decorator type:

```python
class TestModel(TableBase):
        id: int = Field(primary_key=True)
        # This should be BIGINT instead of INTEGER due to explicit_type
        big_number: int = Field(explicit_type=ColumnType.BIGINT)
        # This should be TEXT instead of VARCHAR due to explicit_type
        long_text: str = Field(explicit_type=ColumnType.TEXT)
        # This should be JSONB instead of JSON due to explicit_type
        data: dict = Field(is_json=True, explicit_type=ColumnType.JSONB)
        # Normal field without explicit_type for comparison
        normal_field: str = Field()
```