### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ class Person(TableBase):
     age: int
 ```
 
+Structured JSON values and lightweight scalar subclasses also work naturally in table definitions:
+
+```python
+from iceaxe import Field, TableBase
+from pydantic import BaseModel
+from uuid import UUID
+
+class PersonId(UUID):
+    pass
+
+class Preferences(BaseModel):
+    theme: str
+    notifications: bool
+
+class Person(TableBase):
+    id: PersonId = Field(primary_key=True)
+    preferences: Preferences = Field(is_json=True)
+```
+
+`Field(is_json=True)` will round-trip Pydantic models through a JSON column, and simple subclasses of
+types like `UUID`, `str`, `int`, `date`, and `datetime` are stored using their base Postgres type while
+being returned as their subclass in Python.
+
 Okay now you have a model. How do you interact with it?
 
 Databases are based on a few core primitives to insert data, update it, and fetch it out again.
@@ -105,6 +128,9 @@ For local development or side projects, you can use `magic_migrate` to automatic
 ```python
 await conn.magic_migrate("my_project")
 ```
+
+If you want to limit the sync to a subset of tables or label the generated revision, you can also pass
+`models=[...]` and `message="..."`.
 
 This will:
 1. Compare your current database schema against your model definitions
@@ -228,6 +254,28 @@ results = await conn.exec(query)
 ```
 
 As expected this will deliver results - and typehint - as a `list[tuple[int, FavoriteColor]]`
+
+For the common "fetch the first matching model or fail" case, use `.one()`:
+
+```python
+from iceaxe import NoObjectFound
+
+try:
+    person = await conn.exec(
+        select(Person)
+        .where(Person.id == 1)
+        .one()
+    )
+except NoObjectFound:
+    person = None
+```
+
+`.one()` only applies to a single full-model select like `select(Person)`. It adds `LIMIT 1`,
+returns a single `Person` instead of `list[Person]`, and raises `NoObjectFound` if the query
+returns no rows.
+
+When a query fails, Iceaxe raises `IceaxeQueryError` with the SQL text and variables attached to
+the exception message while still preserving the original asyncpg exception type.
 
 ## Production
 

--- a/docs/api/connection/page.mdx
+++ b/docs/api/connection/page.mdx
@@ -4,3 +4,18 @@ The `DBConnection` class manages all Postgres-Python interactions that actually
 affect the state of the database.
 
 ::: iceaxe.session.DBConnection
+
+---
+
+## Common Exceptions
+
+`DBConnection.exec()` adds a small amount of ORM-specific error handling on top of asyncpg:
+
+- `IceaxeQueryError` wraps failed queries with the SQL text and variables used for execution
+- `NoObjectFound` is raised by `.one()` queries when the database returns no rows
+
+::: iceaxe.exceptions.IceaxeQueryError
+
+---
+
+::: iceaxe.exceptions.NoObjectFound

--- a/docs/guides/logging/page.mdx
+++ b/docs/guides/logging/page.mdx
@@ -24,3 +24,12 @@ easier machine parsing and analysis of query performance.
 ```bash
 {"level": "DEBUG", "name": "iceaxe", "timestamp": "2021-10-14 15:00:00,000", "message": "SELECT * FROM users WHERE id = 1"}
 ```
+
+## Query failure context
+
+When a query fails, `DBConnection.exec()` raises `IceaxeQueryError`. The exception message includes
+the rendered SQL and bound variables, which makes debugging much easier even when debug logging is
+disabled.
+
+Iceaxe preserves the original asyncpg exception hierarchy, so you can still catch specific driver
+errors such as `asyncpg.UniqueViolationError` while benefiting from the extra query context.

--- a/docs/guides/migrations/page.mdx
+++ b/docs/guides/migrations/page.mdx
@@ -73,6 +73,47 @@ migrate-apply = "myproject.cli:apply"
 migrate-rollback = "myproject.cli:rollback"
 ```
 
+## Automatic local schema sync
+
+For local development, `DBConnection.magic_migrate()` combines generation and application into a
+single call:
+
+```python
+await conn.magic_migrate("myproject")
+
+# Limit the sync to specific tables
+await conn.magic_migrate("myproject", models=[Employee, Office])
+
+# Add a message to the generated revision
+await conn.magic_migrate("myproject", message="Add office capacity column")
+```
+
+`magic_migrate()` will:
+
+- introspect the current database schema
+- generate a new migration file only when the schema actually changed
+- apply any pending migrations, including the one it just created
+
+This is a fast workflow for local branches and prototypes. Before merging to production, it is still
+better to review the generated migration files and commit the final revisions explicitly.
+
+## Ignoring externally managed tables
+
+If your database contains tables that Iceaxe should leave alone, you can exclude them during
+migration generation:
+
+```python
+await handle_generate(
+    PROJECT,
+    await get_connection(),
+    ignore_tables=["legacy_audit_log", "spatial_ref_sys"],
+)
+```
+
+Ignored tables are removed from both the in-memory model comparison and the live database
+introspection step. This is useful when your application shares a database with extensions,
+third-party tools, or manually managed tables.
+
 ## Generating migrations
 
 Let's say we currently have a simple Employee table that's defined in our

--- a/docs/guides/selects/page.mdx
+++ b/docs/guides/selects/page.mdx
@@ -56,6 +56,35 @@ are full Python objects; you can access and modify their attributes as you would
 other object. Once received, it's detached from the database connection unless you explicitly
 choose to save it. For more details on how to update data, see the page on [update statements](./inserts).
 
+## Single-row lookups
+
+If you want the first matching model directly instead of a list, call `.one()` on a full-model
+select:
+
+```python
+from iceaxe import NoObjectFound, select
+
+try:
+    employee = await conn.exec(
+        select(Employee)
+        .where(Employee.name == "Marcus Holloway")
+        .order_by(Employee.id, "ASC")
+        .one()
+    )
+except NoObjectFound:
+    employee = None
+```
+
+This is a convenience for the common "give me one model" path:
+
+- `.one()` only works for a single full table selection such as `select(Employee)`
+- It changes the return type from `list[Employee]` to `Employee`
+- It adds `LIMIT 1` to the generated SQL
+- If no rows match, `DBConnection.exec()` raises `NoObjectFound`
+
+`.one()` does not enforce uniqueness. If multiple rows match, it returns the first row from the
+query after ordering and filtering have been applied.
+
 ## NULL Comparisons and Column Comparisons
 
 When working with columns that might contain NULL values, you need to be careful about how you compare them.
@@ -363,4 +392,3 @@ query = select((
 ```
 
 The `alias` function allows you to map SQL results to typed Python values, while `func` provides type-safe SQL function calls. When combined, they enable you to write complex queries with proper type checking and automatic deserialization.
-

--- a/docs/guides/tables/page.mdx
+++ b/docs/guides/tables/page.mdx
@@ -107,3 +107,46 @@ print(person_1)
 person_2 = Person(name="John Doe", age=15)
 print(person_2)
 ```
+
+## Structured JSON fields
+
+`Field(is_json=True)` also supports structured values, including Pydantic models. Iceaxe will infer
+a JSON column for the field and deserialize rows back into the annotated Python type:
+
+```python
+from pydantic import BaseModel
+
+class Preferences(BaseModel):
+    theme: str
+    notifications: bool
+
+class Employee(TableBase):
+    id: int | None = Field(primary_key=True, default=None)
+    name: str
+    preferences: Preferences = Field(is_json=True)
+```
+
+When you insert, select, update, or refresh an `Employee`, the `preferences` attribute remains a
+`Preferences` instance instead of a raw `dict`. If you prefer `JSONB`, you can still override the
+storage type with `Field(is_json=True, explicit_type=ColumnType.JSONB)` after importing
+`ColumnType` from `iceaxe.sql_types`.
+
+## Simple scalar subclasses
+
+Iceaxe also accepts simple subclasses of built-in storage types. This is useful when you want
+domain-specific types without giving up ORM support:
+
+```python
+from uuid import UUID
+
+class EmployeeId(UUID):
+    pass
+
+class Employee(TableBase):
+    id: EmployeeId = Field(primary_key=True)
+    name: str
+```
+
+The value is stored using the base PostgreSQL type, but reads come back as `EmployeeId` instances
+for both full-model selects and direct column selects. This works for simple subclasses of
+`UUID`, `str`, `int`, `float`, `bool`, `bytes`, `date`, `time`, `datetime`, and `timedelta`.


### PR DESCRIPTION
Add some basic documentation for our new exception types alongside examples of how to use magic migrations for local development. This brings documentation inline with our main branch and the new features that we've introduced recently.