### PR TITLE
Add support for json typedicts

### DIFF
--- a/iceaxe/__tests__/schemas/test_db_memory_serializer.py
+++ b/iceaxe/__tests__/schemas/test_db_memory_serializer.py
@@ -1,7 +1,7 @@
 import warnings
 from datetime import date, datetime, time, timedelta
 from enum import Enum, IntEnum, StrEnum
-from typing import Generic, Sequence, TypeVar
+from typing import Generic, Sequence, TypedDict, TypeVar
 from unittest.mock import ANY
 from uuid import UUID
 
@@ -1656,3 +1656,27 @@ def test_pydantic_model_json_field(clear_all_database_objects):
 
     assert settings_column.column_type == ColumnType.JSON
     assert not settings_column.nullable
+
+
+def test_json_container_fields_use_json_column(clear_all_database_objects):
+    class ExampleOption(TypedDict):
+        key: str
+        label: str
+
+    class TestModel(TableBase):
+        id: int = Field(primary_key=True)
+        settings: dict = Field(is_json=True)
+        tags: list[str] = Field(is_json=True)
+        option: ExampleOption = Field(is_json=True)
+        options: list[ExampleOption] = Field(is_json=True)
+
+    migrator = DatabaseMemorySerializer()
+    db_objects = list(migrator.delegate([TestModel]))
+
+    columns = [obj for obj, _ in db_objects if isinstance(obj, DBColumn)]
+
+    for column_name in {"settings", "tags", "option", "options"}:
+        column = next(c for c in columns if c.column_name == column_name)
+        assert column.column_type == ColumnType.JSON
+        assert column.column_is_list is False
+        assert not column.nullable

--- a/iceaxe/__tests__/schemas/test_db_memory_serializer.py
+++ b/iceaxe/__tests__/schemas/test_db_memory_serializer.py
@@ -1,13 +1,14 @@
 import warnings
 from datetime import date, datetime, time, timedelta
 from enum import Enum, IntEnum, StrEnum
-from typing import Generic, Sequence, TypedDict, TypeVar
+from typing import Generic, Sequence, TypeVar
 from unittest.mock import ANY
 from uuid import UUID
 
 import pytest
 from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
+from typing_extensions import TypedDict
 
 from iceaxe import Field, TableBase
 from iceaxe.base import IndexConstraint, UniqueConstraint

--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -2,6 +2,8 @@ from enum import StrEnum
 from typing import Annotated, Any, Generic, TypeVar, cast
 from uuid import UUID
 
+import pytest
+
 from iceaxe.base import (
     DBModelMetaclass,
     TableBase,
@@ -142,3 +144,22 @@ def test_model_fields_with_simple_uuid_subclass():
     assert isinstance(event.id, CustomUUID)
     assert isinstance(event.maybe_id, CustomUUID)
     assert all(isinstance(value, CustomUUID) for value in event.ids)
+
+
+def test_metaclass_resets_construction_state_after_model_error(clear_registry):
+    class BrokenType:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type, handler):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+
+        class BrokenModel(TableBase, autodetect=False):
+            value: BrokenType
+
+    assert DBModelMetaclass.is_constructing is False
+
+    class WorkingModel(TableBase, autodetect=False):
+        id: int
+
+    assert cast(Any, WorkingModel).id.key == "id"

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -741,7 +741,7 @@ async def test_typed_dict_json_round_trip(db_connection: DBConnection):
     await db_connection.conn.execute("DROP TABLE IF EXISTS typeddictjsondemo")
     await create_all(db_connection, [TypedDictJsonDemo])
 
-    options = [
+    options: list[ExampleOption] = [
         {"key": "option_a", "label": "Option A"},
         {"key": "option_b", "label": "Option B"},
     ]

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from enum import StrEnum
 from json import dumps as json_dumps, loads as json_loads
-from typing import Any, Type, TypedDict
+from typing import Any, Type
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
@@ -9,6 +9,7 @@ import asyncpg
 import pytest
 from asyncpg.connection import Connection
 from pydantic import BaseModel
+from typing_extensions import TypedDict
 
 from iceaxe.__tests__.conf_models import (
     ArtifactDemo,

--- a/iceaxe/__tests__/test_session.py
+++ b/iceaxe/__tests__/test_session.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from enum import StrEnum
 from json import dumps as json_dumps, loads as json_loads
-from typing import Any, Type
+from typing import Any, Type, TypedDict
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
@@ -726,6 +726,39 @@ async def test_pydantic_json_deserialization_from_database(
             payload=Preferences(theme="system", notifications=False),
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_typed_dict_json_round_trip(db_connection: DBConnection):
+    class ExampleOption(TypedDict):
+        key: str
+        label: str
+
+    class TypedDictJsonDemo(TableBase):
+        id: int | None = Field(primary_key=True, default=None)
+        options: list[ExampleOption] = Field(is_json=True)
+
+    await db_connection.conn.execute("DROP TABLE IF EXISTS typeddictjsondemo")
+    await create_all(db_connection, [TypedDictJsonDemo])
+
+    options = [
+        {"key": "option_a", "label": "Option A"},
+        {"key": "option_b", "label": "Option B"},
+    ]
+    demo = TypedDictJsonDemo(options=options)
+    await db_connection.insert([demo])
+
+    full_result = await db_connection.exec(
+        QueryBuilder().select(TypedDictJsonDemo).where(TypedDictJsonDemo.id == demo.id)
+    )
+    assert full_result == [TypedDictJsonDemo(id=demo.id, options=options)]
+
+    column_result = await db_connection.exec(
+        QueryBuilder()
+        .select(TypedDictJsonDemo.options)
+        .where(TypedDictJsonDemo.id == demo.id)
+    )
+    assert column_result == [options]
 
 
 @pytest.mark.asyncio

--- a/iceaxe/base.py
+++ b/iceaxe/base.py
@@ -70,9 +70,11 @@ class DBModelMetaclass(_model_construction.ModelMetaclass):
         raw_kwargs = {**kwargs}
 
         mcs.is_constructing = True
-        autodetect = mcs._extract_kwarg(kwargs, "autodetect", True)
-        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
-        mcs.is_constructing = False
+        try:
+            autodetect = mcs._extract_kwarg(kwargs, "autodetect", True)
+            cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        finally:
+            mcs.is_constructing = False
 
         # Allow future calls to subclasses / generic instantiations to reference the same
         # kwargs as the base class

--- a/iceaxe/schemas/db_memory_serializer.py
+++ b/iceaxe/schemas/db_memory_serializer.py
@@ -50,8 +50,8 @@ from iceaxe.sql_types import enum_to_name
 from iceaxe.typing import (
     ALL_ENUM_TYPES,
     DATE_TYPES,
-    JSON_WRAPPER_FALLBACK,
     PRIMITIVE_WRAPPER_TYPES,
+    is_json_container_type,
     resolve_typehint,
 )
 
@@ -435,13 +435,25 @@ class DatabaseHandler:
         # Resolve the type of the column, if generic
         if isinstance(storage_annotation, TypeVar):
             typevar_map = get_typevar_mapping(table)
-            storage_annotation = typevar_map[storage_annotation]
-            resolved_annotation = resolve_typehint(storage_annotation)
+            annotation = typevar_map[storage_annotation]
+            resolved_annotation = resolve_typehint(annotation)
             storage_annotation = (
                 get_simple_subclass_base_type(resolved_annotation.runtime_type)
                 or resolved_annotation.runtime_type
             )
             is_list = resolved_annotation.is_list
+
+        # JSON-backed fields should remain JSON even when their annotation is a
+        # top-level list container such as `list[str]` or `list[TypedDict]`.
+        if info.is_json and (
+            is_type_compatible(annotation, BaseModel)
+            or is_json_container_type(annotation)
+            or is_type_compatible(storage_annotation, BaseModel)
+            or is_json_container_type(storage_annotation)
+        ):
+            return TypeDeclarationResponse(
+                primitive_type=ColumnType.JSON,
+            )
 
         # Should be prioritized in terms of MRO; StrEnums should be processed
         # before the str types
@@ -514,7 +526,7 @@ class DatabaseHandler:
                     f"Pydantic model fields must have Field(is_json=True) specified: {storage_annotation}\n"
                     f"Column: {table.__name__}.{key}"
                 )
-        elif is_type_compatible(storage_annotation, JSON_WRAPPER_FALLBACK):
+        elif is_json_container_type(storage_annotation):
             if info.is_json:
                 return TypeDeclarationResponse(
                     primitive_type=ColumnType.JSON,

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -16,6 +16,7 @@ from typing import (
     Union,
     get_args,
     get_origin,
+    is_typeddict,
 )
 from uuid import UUID
 
@@ -138,6 +139,27 @@ def resolve_typehint(annotation: Any) -> ResolvedTypehint:
         runtime_type=unwrap_annotated(current),
         is_list=is_list,
     )
+
+
+def is_json_container_type(annotation: Any) -> bool:
+    """
+    Return whether an annotation represents a JSON container shape.
+
+    Iceaxe stores `dict[...]`, `list[...]`, plain `dict` / `list`, and
+    `TypedDict` values in JSON columns when `Field(is_json=True)` is specified.
+    This helper intentionally focuses on the container forms that need special
+    schema inference without trying to classify arbitrary JSON-serializable
+    scalar types.
+
+    """
+    annotation = unwrap_annotated(annotation)
+    if annotation in {dict, list}:
+        return True
+    if is_typeddict(annotation):
+        return True
+
+    origin = get_origin(annotation)
+    return origin in {dict, list}
 
 
 def transform_typehint(

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -16,9 +16,11 @@ from typing import (
     Union,
     get_args,
     get_origin,
-    is_typeddict,
+    is_typeddict as stdlib_is_typeddict,
 )
 from uuid import UUID
+
+from typing_extensions import is_typeddict as extensions_is_typeddict
 
 if TYPE_CHECKING:
     from iceaxe.alias_values import Alias
@@ -155,7 +157,7 @@ def is_json_container_type(annotation: Any) -> bool:
     annotation = unwrap_annotated(annotation)
     if annotation in {dict, list}:
         return True
-    if is_typeddict(annotation):
+    if stdlib_is_typeddict(annotation) or extensions_is_typeddict(annotation):
         return True
 
     origin = get_origin(annotation)


### PR DESCRIPTION
Typedicts are just dictionaries for all purposes in the runtime, but during typechecking they allow more richness of checking for valid constructions. We would previously fail to initialize columns that were constructed with `TypeDict` because we didn't understand the introspected typehint. This PR adds proper support for typedicts. Like regular dicts it requires `is_json` to be enabled.