### PR TITLE
Unwrap underlying value from custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,28 +62,43 @@ class Person(TableBase):
     age: int
 ```
 
-Structured JSON values and lightweight scalar subclasses also work naturally in table definitions:
+Structured JSON values and per-model identifier types also work naturally in table definitions:
 
 ```python
-from iceaxe import Field, TableBase
-from pydantic import BaseModel
+from typing import NewType
 from uuid import UUID
 
-class PersonId(UUID):
-    pass
+from iceaxe import Field, TableBase
+from pydantic import BaseModel
+
+PersonId = NewType("PersonId", UUID)
+OrganizationId = NewType("OrganizationId", UUID)
 
 class Preferences(BaseModel):
     theme: str
     notifications: bool
 
+class Organization(TableBase):
+    id: OrganizationId = Field(primary_key=True)
+
 class Person(TableBase):
     id: PersonId = Field(primary_key=True)
+    organization_id: OrganizationId
     preferences: Preferences = Field(is_json=True)
+
+person_id = PersonId(UUID("12345678-1234-5678-1234-567812345678"))
+organization_id = OrganizationId(UUID("87654321-4321-6789-4321-678943216789"))
+preferences = Preferences(theme="dark", notifications=True)
+
+Person(id=person_id, organization_id=organization_id, preferences=preferences)
+Person(id=organization_id, organization_id=person_id, preferences=preferences)  # type checker error
 ```
 
-`Field(is_json=True)` will round-trip Pydantic models through a JSON column, and simple subclasses of
-types like `UUID`, `str`, `int`, `date`, and `datetime` are stored using their base Postgres type while
-being returned as their subclass in Python.
+`Field(is_json=True)` will round-trip Pydantic models through a JSON column. `NewType` identifiers
+are stored using their underlying Postgres type, so `PersonId` and `OrganizationId` are both UUID
+columns while static type checkers can still flag accidentally swapped IDs. Simple subclasses of
+types like `UUID`, `str`, `int`, `date`, and `datetime` are also stored using their base Postgres type
+while being returned as their subclass in Python.
 
 Okay now you have a model. How do you interact with it?
 

--- a/iceaxe/__tests__/schemas/test_db_memory_serializer.py
+++ b/iceaxe/__tests__/schemas/test_db_memory_serializer.py
@@ -1,7 +1,7 @@
 import warnings
 from datetime import date, datetime, time, timedelta
 from enum import Enum, IntEnum, StrEnum
-from typing import Generic, Sequence, TypeVar
+from typing import Generic, NewType, Sequence, TypeVar
 from unittest.mock import ANY
 from uuid import UUID
 
@@ -801,6 +801,36 @@ def test_simple_uuid_subclass_column_assignment(clear_all_database_objects):
                     nullable=False,
                 ),
             ],
+        ),
+    ]
+
+
+def test_uuid_newtype_column_assignment(clear_all_database_objects):
+    UserId = NewType("UserId", UUID)
+
+    class ExampleModel(TableBase):
+        id: UserId = Field(primary_key=True)
+        values: list[UserId]
+
+    columns = [
+        obj
+        for obj, _ in DatabaseMemorySerializer().delegate([ExampleModel])
+        if isinstance(obj, DBColumn)
+    ]
+    assert columns == [
+        DBColumn(
+            table_name="examplemodel",
+            column_name="id",
+            column_type=ColumnType.UUID,
+            column_is_list=False,
+            nullable=False,
+        ),
+        DBColumn(
+            table_name="examplemodel",
+            column_name="values",
+            column_type=ColumnType.UUID,
+            column_is_list=True,
+            nullable=False,
         ),
     ]
 

--- a/iceaxe/__tests__/test_base.py
+++ b/iceaxe/__tests__/test_base.py
@@ -1,9 +1,10 @@
 from enum import StrEnum
-from typing import Annotated, Any, Generic, TypeVar, cast
+from typing import Annotated, Any, Generic, NewType, TypeVar, cast
 from uuid import UUID
 
 import pytest
 
+from iceaxe.__tests__.helpers import pyright_raises
 from iceaxe.base import (
     DBModelMetaclass,
     TableBase,
@@ -144,6 +145,23 @@ def test_model_fields_with_simple_uuid_subclass():
     assert isinstance(event.id, CustomUUID)
     assert isinstance(event.maybe_id, CustomUUID)
     assert all(isinstance(value, CustomUUID) for value in event.ids)
+
+
+def test_uuid_newtype_ids_are_typechecked():
+    UserId = NewType("UserId", UUID)
+    OrganizationId = NewType("OrganizationId", UUID)
+
+    class User(TableBase, autodetect=False):
+        id: UserId = Field(primary_key=True)
+        organization_id: OrganizationId
+
+    raw_id = UUID("12345678-1234-5678-1234-567812345678")
+    user_id = UserId(raw_id)
+    organization_id = OrganizationId(raw_id)
+
+    User(id=user_id, organization_id=organization_id)
+    with pyright_raises("reportArgumentType"):
+        User(id=organization_id, organization_id=user_id)  # type: ignore
 
 
 def test_metaclass_resets_construction_state_after_model_error(clear_registry):

--- a/iceaxe/typing.py
+++ b/iceaxe/typing.py
@@ -69,6 +69,12 @@ def unwrap_annotated(annotation: Any) -> Any:
     return annotation
 
 
+def unwrap_newtype(annotation: Any) -> Any:
+    while hasattr(annotation, "__supertype__"):
+        annotation = annotation.__supertype__
+    return annotation
+
+
 def get_optional_inner(annotation: Any) -> Any | None:
     if not is_union_type(annotation):
         return None
@@ -123,7 +129,7 @@ def resolve_typehint(annotation: Any) -> ResolvedTypehint:
     is_list = False
 
     while True:
-        current = unwrap_annotated(current)
+        current = unwrap_newtype(unwrap_annotated(current))
 
         optional_inner = get_optional_inner(current)
         if optional_inner is not None:
@@ -138,7 +144,7 @@ def resolve_typehint(annotation: Any) -> ResolvedTypehint:
         break
 
     return ResolvedTypehint(
-        runtime_type=unwrap_annotated(current),
+        runtime_type=unwrap_newtype(unwrap_annotated(current)),
         is_list=is_list,
     )
 


### PR DESCRIPTION
It's a bit more ergonomic to use `NewType` than to require subclasses of UUID everywhere you want to use custom identifiers. This PR adds support for unwrapping a NewType at runtime into its underlying base type, to allow for one line shortcuts to both add custom typehinting and still resolve to its correct table column type.